### PR TITLE
Add ConfigMap to Deployment

### DIFF
--- a/common/Chart.yaml
+++ b/common/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 1.17.0

--- a/common/templates/NOTES.txt
+++ b/common/templates/NOTES.txt
@@ -6,13 +6,13 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.name" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.name" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.name" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "common.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")

--- a/common/templates/_helpers.tpl
+++ b/common/templates/_helpers.tpl
@@ -3,25 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "common.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "common.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- default .Release.Name .Values.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -65,7 +47,7 @@ Create the name of the service account to use
 */}}
 {{- define "common.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "common.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "common.name" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/common/templates/_helpers.tpl
+++ b/common/templates/_helpers.tpl
@@ -43,6 +43,15 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "common.podAnnotations" -}}
+annotations:
+  {{- if .Values.podAnnotations -}}
+    {{- .Values.podAnnotations | toYaml . | nindent 2 }}
+  {{- end -}}
+  {{/* https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments */}}
+  checksum/config: {{ .Values.env | toString | sha256sum }}
+{{- end }}
+
 {{/*
 Selector labels
 */}}

--- a/common/templates/configmap.yaml
+++ b/common/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.fullname" . }}-configmap
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  {{- .Values.env | toYaml | nindent 2 }}

--- a/common/templates/configmap.yaml
+++ b/common/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "common.fullname" . }}-configmap
+  name: {{ include "common.name" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 data:

--- a/common/templates/deployment.yaml
+++ b/common/templates/deployment.yaml
@@ -13,10 +13,7 @@ spec:
       {{- include "common.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- include "common.podAnnotations" . | nindent 6 }}
       labels:
         {{- include "common.selectorLabels" . | nindent 8 }}
     spec:
@@ -47,6 +44,9 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.fullname" . }}-configmap
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/common/templates/deployment.yaml
+++ b/common/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "common.name" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 spec:
@@ -24,6 +24,7 @@ spec:
       serviceAccountName: {{ include "common.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -32,21 +33,21 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.serviceContainer.port  }}
+              containerPort: {{ .Values.deploymentContainer.port  }}
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: {{ .Values.serviceContainer.livenessProbe.path }}
+              path: {{ .Values.deploymentContainer.livenessProbe.path }}
               port: http
           readinessProbe:
             httpGet:
-              path:  {{ .Values.serviceContainer.readinessProbe.path }}
+              path:  {{ .Values.deploymentContainer.readinessProbe.path }}
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
             - configMapRef:
-                name: {{ include "common.fullname" . }}-configmap
+                name: {{ include "common.name" . }}-configmap
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/common/templates/deployment.yaml
+++ b/common/templates/deployment.yaml
@@ -38,11 +38,11 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.deploymentContainer.livenessProbe.path }}
-              port: http
+              port: {{ .Values.deploymentContainer.livenessProbe.port }}
           readinessProbe:
             httpGet:
               path:  {{ .Values.deploymentContainer.readinessProbe.path }}
-              port: http
+              port:  {{ .Values.deploymentContainer.readinessProbe.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/common/templates/hpa.yaml
+++ b/common/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "common.name" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "common.fullname" . }}
+    name: {{ include "common.name" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/common/templates/ingress.yaml
+++ b/common/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "common.fullname" . -}}
+{{- $name := include "common.name" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -8,7 +8,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $name }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -34,7 +34,7 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ $name }}
               servicePort: {{ $svcPort }}
           {{- end }}
     {{- end }}

--- a/common/templates/service.yaml
+++ b/common/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "common.name" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 spec:

--- a/common/templates/tests/test-connection.yaml
+++ b/common/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "common.fullname" . }}-test-connection"
+  name: "{{ include "common.name" . }}-test-connection"
   labels:
     {{- include "common.labels" . | nindent 4 }}
   annotations:
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "common.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "common.name" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -4,12 +4,13 @@
 
 replicaCount: 1
 
-serviceContainer:
+deploymentContainer:
   port: 8080
   livenessProbe:
     path: /
   readinessProbe:
     path: /
+  terminationGracePeriodSeconds: 30
 
 image:
   repository: nginx
@@ -18,8 +19,6 @@ image:
   tag: ""
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -27,7 +26,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If not set and create is true, a name is generated using Release.Name
   name: ""
 
 podAnnotations: {}

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -8,8 +8,10 @@ deploymentContainer:
   port: 8080
   livenessProbe:
     path: /
+    port: 8080
   readinessProbe:
     path: /
+    port: 8080
   terminationGracePeriodSeconds: 30
 
 image:

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -84,3 +84,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Environment variables populated into the Deployment's ConfigMap
+env: {}


### PR DESCRIPTION
- Defines Values.env as a map for environment variables
- Uses the sha256 checksum of the stringified `env` variable as an
annotation on the Deployment, to trigger a rolling deployment when the
ConfigMap values change

Example:

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: loomis-staging-common-configmap
  labels:
    helm.sh/chart: common-0.2.0
    app.kubernetes.io/name: common
    app.kubernetes.io/instance: loomis-staging
    app.kubernetes.io/version: "1.17.0"
    app.kubernetes.io/managed-by: Helm
data:
  foo: bar
---

apiVersion: apps/v1
kind: Deployment
metadata:
  name: loomis-staging-common
  labels:
    helm.sh/chart: common-0.2.0
    app.kubernetes.io/name: common
    app.kubernetes.io/instance: loomis-staging
    app.kubernetes.io/version: "1.17.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: common
      app.kubernetes.io/instance: loomis-staging
  template:
    metadata:
      annotations:
        checksum/config: 70b4293cdc4c062ee84daba61e5728dd48b22a6da59512682cd2ff651ff1dd4b
      labels:
        app.kubernetes.io/name: common
        app.kubernetes.io/instance: loomis-staging
    spec:
      serviceAccountName: loomis-staging-common
      securityContext:
        {}
      containers:
        - name: common
          securityContext:
            {}
          image: "gcr.io/internal-1-4825/loomis:1.17.0"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 7337
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /
              port: http
          readinessProbe:
            httpGet:
              path:  /
              port: http
          resources:
            {}
          envFrom:
            - configMapRef:
                name: loomis-staging-common-configmap
```