### PR TITLE
NRD - allow overriding DD_ENV in deployments

### DIFF
--- a/common/Chart.yaml
+++ b/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.6
+version: 0.7.7
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/common/templates/deployment.yaml
+++ b/common/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
                   fieldPath: metadata.name
           {{- if .Values.apm.enabled }}
             - name: DD_ENV
-              value: {{ .Values.environment }}
+              value: {{ .Values.apm.datadogEnvironment | default .Values.environment }}
             - name: DD_TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:

--- a/common/templates/deployment.yaml
+++ b/common/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
                   fieldPath: metadata.name
           {{- if .Values.apm.enabled }}
             - name: DD_ENV
-              value: {{ .Values.apm.datadogEnvironment | default .Values.environment }}
+              value: {{ .Values.apm.datadogEnvironment | default ".Values.environment" }}
             - name: DD_TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -125,6 +125,7 @@ affinity: {}
 # Used for DD_TRACE_AGENT_HOSTNAME on DD APM/Node.js potentially can be used with logger vars too
 apm:
   enabled: false
+  datadogEnvironment: ""
 
 # Default Logger and DD variables are defined here: https://github.com/dave-inc/charts/blob/master/common/templates/deployment.yaml
 # Custom env variables are defined here and will be populated via Deployment's ConfigMap


### PR DESCRIPTION
banking uses prefixed variants: `banking-production` instead of just `production`