### PR TITLE
NRD - deployment updates

### DIFF
--- a/common/Chart.yaml
+++ b/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.10
+version: 0.7.11
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/common/templates/deployment.yaml
+++ b/common/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
           command:
             {{- toYaml .Values.deploymentContainer.command | nindent 12 }}
           {{- end }}
+          {{- if .Values.deploymentContainer.args }}
+          args:
+            {{- toYaml .Values.deploymentContainer.args | nindent 12 }}
+          {{- end }}
           env:
             {{/*
             Environment variables used by the common logger

--- a/common/templates/deployment.yaml
+++ b/common/templates/deployment.yaml
@@ -116,6 +116,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{/*
+            Used by hot-shots package as default StatsD host
+            */}}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: DD_SERVICE_NAME
               value: {{ include "common.name" . }}
           {{- end }}


### PR DESCRIPTION
- Specify `args` in a deployment (for use with secret management)
- Added DD_AGENT_HOST to default env values for [hot-shots](https://www.npmjs.com/package/hot-shots) compatibility (the Dave StatsD client)