### PR TITLE
healthCheck and tls section fix

### DIFF
--- a/common/Chart.yaml
+++ b/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.13
+version: 0.7.14
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/common/templates/backendconfig.yaml
+++ b/common/templates/backendconfig.yaml
@@ -4,6 +4,5 @@ kind: BackendConfig
 metadata:
   name: {{ include "common.name" . }}
 spec:
-  securityPolicy:
-    name: {{ .Values.cloudArmor.securityPolicyName | default (include "common.name" .) | quote }}
+  {{- toYaml .Values.cloudArmor.backendConfig | nindent 2 }}
 {{- end }}

--- a/common/templates/ingress.yaml
+++ b/common/templates/ingress.yaml
@@ -53,12 +53,9 @@ spec:
       {{- end -}}
       {{- end -}}
   {{- end }}
-  {{- if .Values.ingress.tls }}
   tls:
     - secretName: {{ .Values.cloudArmor.secretName }}
-  {{- end }}
   {{- else -}}
-
   {{- range .Values.ingress.hosts -}}
   - host: {{ .host | quote }}
     http:

--- a/common/values.yaml
+++ b/common/values.yaml
@@ -107,6 +107,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  # tls section is not used with using cloudArmor: enabled
 
 cloudArmor:
   enabled: false
@@ -115,9 +116,14 @@ cloudArmor:
   # host and secretName are required to generate a certificate
   host: chart-example.local
   secretName: chart-example-tls
-  # The name of securityPolicy used by backendConfig is optional, If not set, a name is generated using Release.Name
-  # securityPolicy: ""
-  # By default we always use redirectToHttps if you want to define frontendConfig consider including it
+  # securityPolicy is required in backendConfig
+  backendConfig:
+    securityPolicy:
+      name: chart-securitypolicy
+    healthCheck:
+      requestPath: /
+      type: HTTP
+  # By default we always use redirectToHttps in frontendConfig if you want to define overwrite consider including it
   frontendConfig:
     redirectToHttps:
       enabled: true
@@ -125,8 +131,8 @@ cloudArmor:
   # The name of staticIpName is optional, If not set, a name is generated using Release.Name
   # staticIpName: ""
 
+# Used with cloudArmor only
 certificate:
-  # Used with cloudArmor
   issuer: letsencrypt
 
 resources: {}


### PR DESCRIPTION
- BackendConfig fix, includes securityPolicy and healthCheck by default
- With cloudArmor enabled Tls section under Ingress is not required