### PR TITLE
Validate alias, required fields and move host to certificate section in cloudarmor

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.18-beta.3
+version: 0.7.18-beta.4
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -1,9 +1,10 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
 Expand the name of the chart.
 */}}
 {{- define "common.name" -}}
-{{- default .Release.Name .Values.name | trunc 63 | trimSuffix "-" }}
+{{- default .Release.Name ( required ".Values.name is missing, this can be caused by a mismatch in chart alias reference" .Values.name ) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -64,7 +65,5 @@ Create Cloud Armor tls secret name.
 This is needed to avoid overlap with default Service and Ingress (the ones not used by Cloud Armor)
 */}}
 {{- define "common.cloudArmorTlsSecret" -}}
-{{- range .Values.cloudArmor.hosts -}}
-{{- printf "%s-tls" .host | replace "." "-" }}
-{{- end }}
+{{- printf "%s-tls" .Values.cloudArmor.certificate.host | replace "." "-" }}
 {{- end }}

--- a/charts/common/templates/certificate-cloudarmor.yaml
+++ b/charts/common/templates/certificate-cloudarmor.yaml
@@ -4,13 +4,11 @@ kind: Certificate
 metadata:
   name: {{ include "common.name" . }}
 spec:
-  secretName: {{ .Values.cloudArmor.secretName | default (include "common.cloudArmorTlsSecret" .) }}
+  secretName: {{ .Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" .) }}
   issuerRef:
     kind: ClusterIssuer
     name: {{ .Values.cloudArmor.certificate.issuer }}
-  {{ range .Values.cloudArmor.hosts -}}
-  commonName: {{ .host | quote }}
+  commonName: {{ .Values.cloudArmor.certificate.host | quote }}
   dnsNames:
-    - {{ .host | quote }}
-  {{- end }}
+    - {{ .Values.cloudArmor.certificate.host | quote }}
 {{- end }}

--- a/charts/common/templates/ingress-cloudarmor.yaml
+++ b/charts/common/templates/ingress-cloudarmor.yaml
@@ -14,10 +14,9 @@ metadata:
     networking.gke.io/v1beta1.FrontendConfig: {{ include "common.name" . }}
 spec:
   rules:
-  {{ range .Values.cloudArmor.hosts -}}
   - http:
       paths:
-      {{- range .paths }}
+      {{- range .Values.cloudArmor.paths }}
       - backend:
         {{- range $backend, $service := .backend }}
           service:
@@ -31,8 +30,7 @@ spec:
         {{- end }}
         path: {{ .path | default "/*" }}
         pathType: {{ .pathType | default "ImplementationSpecific" }}
-      {{- end -}}
-  {{- end }}
+      {{- end }}
   tls:
     - secretName: {{ include "common.cloudArmorTlsSecret" . }}
 {{- end }}

--- a/charts/common/templates/serviceaccount.yaml
+++ b/charts/common/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "common.labels" . | nindent 4 }}
   annotations:
-    iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.workloadIdentitySA | default (include "common.serviceAccountName" .) }}@{{ required "A valid GCP Project id is required!" .Values.project }}.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.workloadIdentitySA | default (include "common.serviceAccountName" .) }}@{{ required ".Values.project missing, valid GCP ProjectId is required" .Values.project }}.iam.gserviceaccount.com
     {{ with .Values.serviceAccount.annotations }}
     {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -117,15 +117,19 @@ cloudArmor:
   # If you overwrite <name> it should match <serviceName> under the hosts section
   annotations: {}
   hosts:
-    - host: chart-example.local
-      paths:
-        - backend:
-            serviceName: <chart-service>-ca
-            servicePort: 80
-          path: /*
-          pathType: ImplementationSpecific
-  # secretName is optional, if not set, a name is generated using <host> will be converted to chart-example-local-tls
-  # secretName: chart-example-local-tls
+    paths:
+      - backend:
+          service:
+            name: chart-service-ca
+            port:
+              number: 80
+        path: /*
+        pathType: ImplementationSpecific
+  certificate:
+    host: chart-example.local
+    # secretName is optional, if not set, a name is generated using <host> will be converted to chart-example-local-tls
+    # secretName: chart-example-local-tls
+    issuer: letsencrypt
   # securityPolicy is required in backendConfig. This is a resource in GCP.
   backendConfig:
     securityPolicy:
@@ -143,8 +147,6 @@ cloudArmor:
   # cloudArmor needs a service type NodePort
   service:
     type: NodePort
-  certificate:
-    issuer: letsencrypt
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
- Validate alias name
- More descriptive message for required fields
- Move `host` and `secretName` to `certificate` section in `cloudArmor`