### PR TITLE
fix the quotes for dd version

### DIFF
--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -15,8 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
-
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/job/templates/cronjob.yaml
+++ b/charts/job/templates/cronjob.yaml
@@ -40,7 +40,7 @@ spec:
             {{- end }}
           labels:
             run: {{ include "job.name" . }}
-            tags.datadoghq.com/version: {{ .Values.image.tag }}
+            tags.datadoghq.com/version: "{{ .Values.image.tag }}"
             {{- include "job.selectorLabels" . | nindent 12 }}
         spec:
           {{- with .Values.imagePullSecrets }}

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -24,7 +24,7 @@ spec:
         {{- end }}
       labels:
         run: {{ include "job.name" . }}
-        tags.datadoghq.com/version: {{ .Values.image.tag }}
+        tags.datadoghq.com/version: "{{ .Values.image.tag }}"
         {{- include "job.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
the dd version tag was not always wrapped in quotes, so when using a git commit short hash there could be a bug ( there currently is with a deployment 😅 ) where the short hash has no letters in it, and is read as an int64. this should force a string for any value passed in