### PR TITLE
[SRE-1087] common chart minor bug fixes

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0-beta.2
+version: 0.8.0-beta.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -66,6 +66,6 @@ This is needed to avoid overlap with default Service and Ingress (the ones not u
 */}}
 {{- define "common.cloudArmorTlsSecret" -}}
 {{- if .Values.cloudArmor.enabled }}
-{{- printf "%s-tls" .Values.cloudArmor.certificate.host | replace "." "-" }}
+{{- printf "%s-ca-tls" .Values.cloudArmor.certificate.host | replace "." "-" }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "common.name" . }}
   labels:
     tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+    run: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
@@ -26,6 +27,7 @@ spec:
         {{- end }}
       labels:
         tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+        run: {{ include "common.name" . }}
         {{- include "common.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -44,7 +44,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ .secretName | default $hostwithdashestls }}
     {{- end -}}
   {{- else }}
   tls:

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.cloudArmor.enabled -}}
-{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,5 +16,4 @@ spec:
       name: http
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}
-{{- end }}
 {{- end }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -131,7 +131,7 @@ ingress:
       # The name is optional, If not set, a name is generated using host
       # name: ""
       annotations: {}
-        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/ingress.class: (nginx-internal or nginx-public)
         # kubernetes.io/tls-acme: "true"
       paths:
         - backend:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -145,7 +145,6 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  # tls section is not used with using cloudArmor: enabled
 
 cloudArmor:
   enabled: false
@@ -163,8 +162,8 @@ cloudArmor:
       pathType: ImplementationSpecific
   certificate:
     host: chart-example.local
-    # secretName is optional, if not set, a name is generated using <host> will be converted to chart-example-local-tls
-    # secretName: chart-example-local-tls
+    # secretName is optional, if not set, a name is generated using <host> will be converted to chart-example-local-ca-tls
+    # secretName: chart-example-local-ca-tls
     issuer: letsencrypt
     # alternativeDnsNames:
     #  - www.chart-example.local


### PR DESCRIPTION
- change the default CA cert secret name to include `-ca-` in the name to avoid conflicts with nginx
- Add label `run` to deployments  with value `common.name`
- Set default secret name for nginx to `$hostwithdashestls` if no name was given.
- Removed check for `.Values.service.enabled` on CA setup as the services are not shared.
- Minimal documentation changes to match the changes above