### PR TITLE
Release 0.8.0

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0-beta.3
+version: 0.8.0
 
 
 # This is the version number of the application being deployed. This version number should be


### PR DESCRIPTION
Release `common-0.8.0`

[common-0.8.0-beta.3](https://github.com/dave-inc/charts/releases/tag/common-0.8.0-beta.3)
- Change the default CA cert secret name to include -ca- in the name to avoid conflicts with nginx
- Add label run to deployments with value common.name
- Set default secret name for nginx tls to $hostwithdashestls if no name was given.
- Removed check for .Values.service.enabled on CA setup as the services are not shared.
- Minimal documentation changes to match the changes above

[common-0.8.0-beta.2](https://github.com/dave-inc/charts/releases/tag/common-0.8.0-beta.2)
- Added Startup Probe
- Added custom Probes for Liveness, Readiness and Startup to use different checks mechanism as: exec, grcp and tcpSocket.
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

[common-0.8.0-beta.1](https://github.com/dave-inc/charts/releases/tag/common-0.8.0-beta.1)
- Fixes log-parameters output in migration workflow template