### PR TITLE
[SRE-1614] Support optional config files through a configmap

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1-beta.1
+version: 0.8.1-beta.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -69,3 +69,10 @@ This is needed to avoid overlap with default Service and Ingress (the ones not u
 {{- printf "%s-ca-tls" .Values.cloudArmor.certificate.host | replace "." "-" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Name for the custom config configmap.
+*/}}
+{{- define "common.customConfig.name" -}}
+{{ .Values.customConfig.name | default (print (include "common.name" .) "-customconfig") }}
+{{- end -}}

--- a/charts/common/templates/configmap-customconfig.yaml
+++ b/charts/common/templates/configmap-customconfig.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.customConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.customConfig.name" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  {{- .Values.customConfig.data | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -196,6 +196,15 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
+          {{- if .Values.customConfig.enabled }}
+            {{ $path := .Values.customConfig.path }}
+            {{- range $fileName, $_ := .Values.customConfig.data }}
+            - name: customconfig-vol
+              mountPath: {{ $path }}/{{ $fileName }}
+              subPath: {{ $fileName }}
+              readOnly: true
+            {{- end }}
+          {{- end }}
 
           {{- if .Values.cloudsqlProxy.enabled }}
         - name: {{ .Values.cloudsqlProxy.name }}
@@ -243,6 +252,11 @@ spec:
             defaultMode: {{ .defaultMode }}
         {{- end }}
       {{- end}}
+      {{- if .Values.customConfig.enabled }}
+        - name: customconfig-vol
+          configMap:
+            name: {{ include "common.customConfig.name" . }}
+      {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -320,3 +320,17 @@ cloudsqlProxy:
     #instanceConnectionName: project_name:region:instance_name
     port: 3306
     secretName: migration
+
+# Generic mechanism to introduce arbitrary config files backed by a k8s ConfigMap.
+# If the file already exists on the given `path`, this will overwrite it.
+customConfig:
+  enabled: false
+  # If `name` is not defined, it will be Release.Name + '-customconfig'.
+  name: ""
+  path: /opt/app/config
+  data: {}
+#   default.json: |
+#      {
+#        "whatever": "your",
+#        "project": "secret:needs"
+#      }


### PR DESCRIPTION
**Ticket**
[SRE-1614](https://demoforthedaves.atlassian.net/browse/SRE-1614)

**Ticket and brief summary**
Support optional config files through a configmap

**How did you test your code?**
`helm template --set name=xyz,project=xyz,customConfig.enabled=true,customConfig.data.xyz=asdf .`

**How will you confirm this change is working once it's deployed?**
Apply it to `promotions-api`.
