### PR TITLE
[SRE-2044] Add support for PodDisruptionBudget

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2-beta
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 spec:
 {{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
-  minAvailable: "13%"
+  minAvailable: "15%"
 {{- end}}
 {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.name" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
+  minAvailable: "13%"
+{{- end}}
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "common.labels" . | nindent 6 }}
+{{- end }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -334,3 +334,19 @@ customConfig:
 #        "whatever": "your",
 #        "project": "secret:needs"
 #      }
+
+# PodDisruptionBudget
+#
+# minAvailable and maxUnavailable are mutually exclusive, only one should be set.
+#
+# If podDisruptionBudget is enabled but no minAvailable or maxUnavailable fields
+# are set, the PodDisruptionTemplate template will default to `minAvailable: 15%`.
+#
+# The value for minAvailable and maxUnavailable should either be set to an integer
+# or a percentage.  For more information see the official documentation:
+#
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: "15%"
+  # maxUnavailable: 5


### PR DESCRIPTION
**Ticket**
[SRE-2044](https://demoforthedaves.atlassian.net/browse/SRE-2044)

**Ticket and brief summary**
PodDisruptionBudget support for Common Chart

Disabled by default.

minAvailable and maxUnavailable are mutually exclusive, only one should be set.

If podDisruptionBudget is enabled but no minAvailable or maxUnavailable fields
are set, the PodDisruptionTemplate template will default to `minAvailable: 15%`.

The value for minAvailable and maxUnavailable should either be set to an integer
or a percentage.  For more information see the official documentation:

[https://kubernetes.io/docs/tasks/run-application/configure-pdb/](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

**How did you test your code?**
Local testing via `helm template`

**How will you confirm this change is working once it's deployed?**
If enabled, a `PodDisruptionBudget` will be set with the given settings.


[SRE-2044]: https://demoforthedaves.atlassian.net/browse/SRE-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ