### PR TITLE
[SRE-2045] Add support for VerticalPodAutoscaler

### DIFF
--- a/charts/common/templates/vpa.yaml
+++ b/charts/common/templates/vpa.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "common.name" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: {{ include "common.name" . }}
+  updatePolicy:
+    # Purposely harcoded to "Off"
+    updateMode: "Off"
+{{- end }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -350,3 +350,23 @@ podDisruptionBudget:
   enabled: false
   # minAvailable: "15%"
   # maxUnavailable: 5
+
+# VerticalPodAutoscaler
+#
+# TODO: (maybe) Support for "Initial", "Auto" and "Recreate" updateModes.
+#
+# Requires Vertical Pod Autoscaling feature to be enabled on the target GKE cluster
+#
+# VirtualPodAutoscaler's updateMode is hardcoded to "Off".  Purposely not allowing
+# "Initial", "Auto" and "Recreate" updateModes to be used as further understanding
+# of how the VPA work is required, specially if used in conjuction with HPAs.  When
+# updateMode is set to "Off", no vertical autoscaling actions are taken.  The purpose
+# of enabling the VPA with updateMode set to "Off" is to get recommendations on what
+# initial settings should be for resource requests and limits based on current
+# workloads.
+#
+# For more information refer to the GKE documentation on VPAs:
+#
+# https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler
+verticalPodAutoscaler:
+  enabled: false


### PR DESCRIPTION
**Ticket**
[SRE-2045](https://demoforthedaves.atlassian.net/browse/SRE-2045)

**Ticket and brief summary**
`VerticalPodAutoscaler`

*Requires* Vertical Pod Autoscaling feature to be enabled on the target GKE cluster

`VirtualPodAutoscaler`'s updateMode is hardcoded to `"Off"`.  Purposely not allowing
`"Initial"`, `"Auto"` and `"Recreate"` updateModes to be used as further understanding
of how the VPA work is required, specially if used in conjuction with HPAs.  When
updateMode is set to `"Off"`, no vertical autoscaling actions are taken.  The purpose
of enabling the VPA with updateMode set to `"Off"` is to get recommendations on what
initial settings should be for resource requests and limits based on current
workloads.

For more information refer to the GKE documentation on VPAs:

[https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler](https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler)

**How did you test your code?**
Local tests via `helm template`

**How will you confirm this change is working once it's deployed?**
When `VerticalPodAutoscaler` is enabled, a VPA configuration will be created pointing to the target deployment.


[SRE-2045]: https://demoforthedaves.atlassian.net/browse/SRE-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ