### PR TITLE
[NT] Add option to override default pod selector labels

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3-beta.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -20,7 +20,12 @@ spec:
 {{- end }}
   selector:
     matchLabels:
+    {{- if not .Values.podSelectorLabelsOverride }}
       {{- include "common.selectorLabels" . | nindent 6 }}
+    {{- end }}
+    {{- if .Values.podSelectorLabelsOverride }}
+      {{- .Values.podSelectorLabelsOverride | toYaml | nindent 6 }}
+    {{- end }}
   strategy:
     {{- toYaml .Values.strategy | nindent 6 }}
   template:
@@ -35,8 +40,13 @@ spec:
         {{- end }}
       labels:
         tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+      {{- if not .Values.podSelectorLabelsOverride }}
         run: {{ include "common.name" . }}
         {{- include "common.selectorLabels" . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podSelectorLabelsOverride }}
+        {{- .Values.podSelectorLabelsOverride | toYaml | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -15,5 +15,10 @@ spec:
       protocol: TCP
       name: http
   selector:
+  {{- if not .Values.podSelectorLabelsOverride }}
     {{- include "common.selectorLabels" . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.podSelectorLabelsOverride }}
+    {{- .Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -17,5 +17,10 @@ spec:
       protocol: TCP
       name: http
   selector:
+  {{- if not .Values.podSelectorLabelsOverride }}
     {{- include "common.selectorLabels" . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.podSelectorLabelsOverride }}
+    {{- .Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -370,3 +370,8 @@ podDisruptionBudget:
 # https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler
 verticalPodAutoscaler:
   enabled: false
+
+#  This is used to override "common.selectorLabels" on deployment, pods and services
+#  used mostly only when importing legacy deployments.
+
+podSelectorLabelsOverride: {}


### PR DESCRIPTION
Adding the option to override the default pod selector labels on deployment, pods and services 

``` # Source: promotions-api/charts/promotions-api/templates/deployment.yaml
 apiVersion: apps/v1
@@ -60,8 +59,7 @@
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/name: promotions-api
-      app.kubernetes.io/instance: promotions-api
+      customSelectorLabel: overridede_value
```

This helps when importing deployments to avoid recreation

$ kubectl diff -f TMP-new-promotions-api.yaml
The Deployment "promotions-api" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"promotions-api", "app.kubernetes.io/name":"promotions-api"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable