### PR TITLE
[SRE-1867] Adding options dd_service_name env overrides

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.3-beta.1
+version: 0.8.3-beta.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -167,8 +167,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{- if not .Values.apm.datadogSkipServiceName }}
             - name: DD_SERVICE_NAME
-              value: {{ include "common.name" . }}
+              value: {{ .Values.apm.datadogServiceName | default (include "common.name" .) }}
+            {{- end }}
           {{- end }}
           envFrom:
             {{- if .Values.existingConfigMapName }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -250,6 +250,12 @@ apm:
   enabled: false
   # If datadogEnvironment is not defined we use variable environment as default
   datadogEnvironment: ""
+  # Optional override DD_SERVICE_NAME to a custon name instead of common.name
+  datadogServiceName: ""
+  # Optional bool used to avoid definition of env DD_SERVICE_NAME
+  # Used to support imported workloads from legacy projects
+  # DD_SERVICE_NAME will take the value from the app name in package.json.
+  # datadogSkipServiceName: false
 
 # Default Logger and DD variables are defined here: https://github.com/dave-inc/charts/blob/master/common/templates/deployment.yaml
 # Custom env variables are defined here and will be populated via Deployment's ConfigMap


### PR DESCRIPTION
Adding options to override the value of `common.name`  from the DD_SERVICE_NAME env variable when APM is enabled.

```
apm:
  enabled: true
  datadogServiceName: custom_dd_service_name
 ```
 
 Also adding an option to skip the definition of `DD_SERVICE_NAME` altogether so the DD integration takes the name of the app from package.json ( required only for some deployment imports from legacy ) without affecting the definition of other DD required environment variables
