### PR TITLE
[SEC-3505] Add jobName to job Chart

### DIFF
--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5-beta.1
+version: 0.1.5-beta.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/job/templates/cronjob.yaml
+++ b/charts/job/templates/cronjob.yaml
@@ -2,9 +2,15 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
+  {{- if .Values.jobName }}
+  name: {{ .Values.jobName }}
+  labels:
+    run: {{ .Values.jobName }}
+  {{- else }}
   name: {{ include "job.name" . }}
   labels:
     run: {{ include "job.name" . }}
+  {{- end }}
 spec:
   schedule: "{{ .Values.schedule }}"
   suspend: {{ .Values.suspend }}
@@ -42,7 +48,11 @@ spec:
             {{- toYaml .Values.podAnnotations | nindent 12 }}
             {{- end }}
           labels:
+            {{- if .Values.jobName }}
+            run: {{ .Values.jobName }}
+            {{- else }}
             run: {{ include "job.name" . }}
+            {{- end }}
             tags.datadoghq.com/version: "{{ .Values.image.tag }}"
             {{- include "job.selectorLabels" . | nindent 12 }}
         spec:

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -33,8 +33,9 @@ initContainer:
 
 imagePullSecrets: []
 
-### The following variables only apply for cronjobs: schedule. suspend, failedJobsHistoryLimit, startingDeadlineSeconds, concurrencyPolicy
+### The following variables only apply for cronjobs: jobName, schedule. suspend, failedJobsHistoryLimit, startingDeadlineSeconds, concurrencyPolicy
 # schedule timezone is UTC
+jobName: ""
 schedule: "* 0 * * *"
 suspend: false
 failedJobsHistoryLimit: ""


### PR DESCRIPTION
[SEC-3505](https://demoforthedaves.atlassian.net/browse/SEC-3505)

Adding `jobName` to the `job` chart to more safely support multiple jobs in the same cluster/namespace/deployment.

[SEC-3505]: https://demoforthedaves.atlassian.net/browse/SEC-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ