### PR TITLE
[SEC-3121] Support external secrets in cronjob sidecars

### DIFF
--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5-beta.1
+version: 0.1.5-beta.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/job/templates/cronjob.yaml
+++ b/charts/job/templates/cronjob.yaml
@@ -90,6 +90,26 @@ spec:
               lifecycle:
                 {{- toYaml .Values.sideCar.lifecycle | nindent 16 }}
               {{- end }}
+              envFrom:
+                {{- if .Values.existingConfigMapName }}
+                - configMapRef:
+                    name: {{ .Values.existingConfigMapName }}
+                {{- end }}
+                {{- if .Values.env }}
+                - configMapRef:
+                    name: {{ .Values.configMapName | default (include "job.name" .) }}
+                {{- end}}
+                {{- if and (.Values.createSecret) (not .Values.createSecretName) }}
+                - secretRef:
+                    name: {{ include "job.name" . }}
+                {{- else if and (.Values.createSecret) (.Values.createSecretName) }}
+                - secretRef:
+                    name: {{ .Values.createSecretName }}
+                {{- else if and (.Values.existingSecretName) (not .Values.createSecret) }}
+                - secretRef:
+                    name: {{ .Values.existingSecretName }}
+                {{- else }}
+                {{- end }}
             {{- end }}
             - name: {{ include "job.name" . }}
               {{- if .Values.securityContext }}

--- a/charts/job/templates/cronjob.yaml
+++ b/charts/job/templates/cronjob.yaml
@@ -90,6 +90,7 @@ spec:
               lifecycle:
                 {{- toYaml .Values.sideCar.lifecycle | nindent 16 }}
               {{- end }}
+              {{- if .Values.sideCar.envFromMainContainer }}
               envFrom:
                 {{- if .Values.existingConfigMapName }}
                 - configMapRef:
@@ -110,6 +111,7 @@ spec:
                     name: {{ .Values.existingSecretName }}
                 {{- else }}
                 {{- end }}
+              {{- end }}
             {{- end }}
             - name: {{ include "job.name" . }}
               {{- if .Values.securityContext }}

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -74,6 +74,28 @@ spec:
           lifecycle:
             {{- toYaml .Values.sideCar.lifecycle | nindent 12 }}
           {{- end }}
+          {{- if .Values.sideCar.envFromMainContainer }}
+          envFrom:
+            {{- if .Values.existingConfigMapName }}
+            - configMapRef:
+                name: {{ .Values.existingConfigMapName }}
+            {{- end }}
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ .Values.configMapName | default (include "job.name" .) }}
+            {{- end}}
+            {{- if and (.Values.createSecret) (not .Values.createSecretName) }}
+            - secretRef:
+                name: {{ include "job.name" . }}
+            {{- else if and (.Values.createSecret) (.Values.createSecretName) }}
+            - secretRef:
+                name: {{ .Values.createSecretName }}
+            {{- else if and (.Values.existingSecretName) (not .Values.createSecret) }}
+            - secretRef:
+                name: {{ .Values.existingSecretName }}
+            {{- else }}
+            {{- end }}
+          {{- end }}
         {{- end }}
         - name: {{ include "job.name" . }}
           {{- if .Values.securityContext }}

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -159,3 +159,6 @@ sideCar:
         command: ['/bin/sh','-c','/bin/sleep 30']
   # VolumeName used when sharing volume with mainContainer, make sure matches the name in sideCar.volumeMounts (mostly used for cloudsql-proxy)
   #volumeName: sidecar
+
+  # Inherit environment variables that are also defined for the main container (through configmaps, secrets, etc)
+  envFromMainContainer: false


### PR DESCRIPTION
**Ticket**
[SEC-3121](https://demoforthedaves.atlassian.net/browse/SEC-3121)

**Ticket and brief summary**
Adding support for cronjob sidecars to mount secrets in support of dave-inc/sre#3222

[SEC-3121]: https://demoforthedaves.atlassian.net/browse/SEC-3121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ