### PR TITLE
[DPE-262] Chart for scheduled tekton jobs

### DIFF
--- a/charts/tekton-cron-jobs/.helmignore
+++ b/charts/tekton-cron-jobs/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/tekton-cron-jobs/Chart.yaml
+++ b/charts/tekton-cron-jobs/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: tekton-cron-jobs
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/tekton-cron-jobs/README.md
+++ b/charts/tekton-cron-jobs/README.md
@@ -1,0 +1,35 @@
+# Tekton scheduled pipelines
+
+This just assists runing tekton pipelines on a schedule
+
+This chart creates an `EventListener` for all jobs, `Trigger`, `TriggerBindings` and `Cron` for each scheduled job. `TriggerTemplate` must be provided from outside.
+
+### Values.yaml
+
+
+Minimal example:
+
+```yaml
+eventListener: {}
+jobs:
+  sentinel:
+    schedule: "*/1 * * * *"
+    triggerTemplate: "wat"
+    params:
+      repo: "tekton"
+```
+
+All possible options (default values used as an example):
+
+```yaml
+eventListener:
+  name: "tekton-cron"
+  replicas: 2
+  serviceAccountName: "tekton-pipelines"
+jobs:
+  sentinel:
+    schedule: "*/1 * * * *"
+    triggerTemplate: "wat"
+    params:
+      repo: "tekton"
+```

--- a/charts/tekton-cron-jobs/templates/_helpers.tpl
+++ b/charts/tekton-cron-jobs/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tekton-cron-jobs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tekton-cron-jobs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tekton-cron-jobs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tekton-cron-jobs.labels" -}}
+helm.sh/chart: {{ include "tekton-cron-jobs.chart" . }}
+{{ include "tekton-cron-jobs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tekton-cron-jobs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tekton-cron-jobs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tekton-cron-jobs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tekton-cron-jobs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "tekton-cron-jobs.eventListenerName" }}
+{{- .Values.eventListener.name | default "tekton-cron" }}
+{{- end }}

--- a/charts/tekton-cron-jobs/templates/cron.yaml
+++ b/charts/tekton-cron-jobs/templates/cron.yaml
@@ -1,0 +1,24 @@
+{{- range $name, $val := .Values.jobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $name }}-cron
+spec:
+  schedule: {{ $val.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            args: ["curl", "-X", "POST", "--data", "{\"job\": \"{{ $name }}\"}", "el-{{ template "tekton-cron-jobs.eventListenerName" .Values }}.$(NAMESPACE).svc.cluster.local:8080"]
+            env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          restartPolicy: Never
+
+{{- end }}

--- a/charts/tekton-cron-jobs/templates/event-listener.yaml
+++ b/charts/tekton-cron-jobs/templates/event-listener.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   triggers:
   {{- range $name, $val := .Values.jobs }}
-    - {{ $name }}-cron-trigger
+    - triggerRef: {{ $name }}-cron-trigger
   {{- end }}
   resources:
     kubernetesResource:

--- a/charts/tekton-cron-jobs/templates/event-listener.yaml
+++ b/charts/tekton-cron-jobs/templates/event-listener.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: {{ include "tekton-cron-jobs.eventListenerName" . }}
+spec:
+  triggers:
+  {{- range $name, $val := .Values.jobs }}
+    - {{ $name }}-cron-trigger
+  {{- end }}
+  resources:
+    kubernetesResource:
+      replicas: {{ .Values.eventListener.replicas | default 2 }}
+      spec:
+        template:
+          spec:
+            serviceAccountName: {{ .Values.eventListener.serviceAccountName | default "tekton-pipelines" }}
+            containers:
+              - resources:
+                  requests:
+                    memory: "64Mi"
+                    cpu: "250m"
+                  limits:
+                    memory: "128Mi"
+                    cpu: "500m"
+

--- a/charts/tekton-cron-jobs/templates/trigger.yaml
+++ b/charts/tekton-cron-jobs/templates/trigger.yaml
@@ -1,0 +1,19 @@
+{{- range $name, $val := .Values.jobs }}
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: {{ $name }}-cron-trigger
+spec:
+  interceptors:
+    - name: "Filter by name"
+      ref:
+        name: "cel"
+      params:
+        - name: "filter"
+          value: "body.job == '{{ $name }}'"
+  bindings:
+    - ref: {{ $name }}-cron-bindings
+  template:
+    ref: {{ $val.triggerTemplate }}
+{{- end }}

--- a/charts/tekton-cron-jobs/templates/triggerbindings.yaml
+++ b/charts/tekton-cron-jobs/templates/triggerbindings.yaml
@@ -1,0 +1,13 @@
+{{- range $name, $val := .Values.jobs }}
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: {{ $name }}-cron-bindings
+spec:
+  params:
+    {{- range $k, $v := $val.params }}
+    - name: {{ $k | quote }}
+      value: {{ $v | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/tekton-cron-jobs/values-example.yaml
+++ b/charts/tekton-cron-jobs/values-example.yaml
@@ -2,6 +2,6 @@ eventListener: {}
 jobs:
   sentinel:
     schedule: "*/1 * * * *"
-    triggerTemplate: "wat"
+    triggerTemplate: "sentinel"
     params:
       repo: "tekton"

--- a/charts/tekton-cron-jobs/values-example.yaml
+++ b/charts/tekton-cron-jobs/values-example.yaml
@@ -1,0 +1,7 @@
+eventListener: {}
+jobs:
+  sentinel:
+    schedule: "*/1 * * * *"
+    triggerTemplate: "wat"
+    params:
+      repo: "tekton"

--- a/charts/tekton-cron-jobs/values.yaml
+++ b/charts/tekton-cron-jobs/values.yaml
@@ -1,0 +1,1 @@
+eventListener: {}


### PR DESCRIPTION
Adds a chart to assist in running tekton pipelines on a schedule.

Works by triggering job from k8s's CronJob via curl.

<details><summary>Example output</summary>

```yaml
---
# Source: tekton-cron-jobs/templates/cron.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: sentinel-cron
spec:
  schedule: "*/1 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: trigger
            image: curlimages/curl
            args: ["curl", "-X", "POST", "--data", "{\"job\": \"sentinel\"}", "el-tekton-cron.$(NAMESPACE).svc.cluster.local:8080"]
            env:
            - name: NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
          restartPolicy: Never
---
# Source: tekton-cron-jobs/templates/event-listener.yaml
apiVersion: triggers.tekton.dev/v1beta1
kind: EventListener
metadata:
  name: tekton-cron
spec:
  triggers:
    - sentinel-cron-trigger
  resources:
    kubernetesResource:
      replicas: 2
      spec:
        template:
          spec:
            serviceAccountName: tekton-pipelines
            containers:
              - resources:
                  requests:
                    memory: "64Mi"
                    cpu: "250m"
                  limits:
                    memory: "128Mi"
                    cpu: "500m"
---
# Source: tekton-cron-jobs/templates/trigger.yaml
apiVersion: triggers.tekton.dev/v1beta1
kind: Trigger
metadata:
  name: sentinel-cron-trigger
spec:
  interceptors:
    - name: "Filter by name"
      ref:
        name: "cel"
      params:
        - name: "filter"
          value: "body.job == 'sentinel'"
  bindings:
    - ref: sentinel-cron-bindings
  template:
    ref: wat
---
# Source: tekton-cron-jobs/templates/triggerbindings.yaml
apiVersion: triggers.tekton.dev/v1beta1
kind: TriggerBinding
metadata:
  name: sentinel-cron-bindings
spec:
  params:
    - name: "repo"
      value: "tekton"
```
</details>