### PR TITLE
[SRE-3115] Add http headers for liveness/readiness/startup probes

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.3-beta.5
+version: 0.8.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             httpGet:
               path: {{ .Values.deploymentContainer.livenessProbe.path }}
               port: {{ .Values.deploymentContainer.livenessProbe.port | default .Values.deploymentContainer.port }}
+              {{- if .Values.deploymentContainer.livenessProbe.httpHeaders }}
+              httpHeaders:
+                {{- toYaml .Values.deploymentContainer.livenessProbe.httpHeaders | nindent 16 }}
+              {{- end }}
             failureThreshold: {{ .Values.deploymentContainer.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.deploymentContainer.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.deploymentContainer.livenessProbe.periodSeconds }}
@@ -94,6 +98,10 @@ spec:
             httpGet:
               path: {{ .Values.deploymentContainer.readinessProbe.path }}
               port: {{ .Values.deploymentContainer.readinessProbe.port | default .Values.deploymentContainer.port }}
+              {{- if .Values.deploymentContainer.readinessProbe.httpHeaders }}
+              httpHeaders:
+                {{- toYaml .Values.deploymentContainer.readinessProbe.httpHeaders | nindent 16 }}
+              {{- end }}
             failureThreshold: {{ .Values.deploymentContainer.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.deploymentContainer.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.deploymentContainer.readinessProbe.periodSeconds }}
@@ -108,6 +116,10 @@ spec:
             httpGet:
               path: {{ .Values.deploymentContainer.startupProbe.path }}
               port: {{ .Values.deploymentContainer.startupProbe.port | default .Values.deploymentContainer.port }}
+              {{- if .Values.deploymentContainer.startupProbe.httpHeaders }}
+              httpHeaders:
+                {{- toYaml .Values.deploymentContainer.startupProbe.httpHeaders | nindent 16 }}
+              {{- end }}
             failureThreshold: {{ .Values.deploymentContainer.startupProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.deploymentContainer.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.deploymentContainer.startupProbe.periodSeconds }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -30,6 +30,9 @@ deploymentContainer:
   livenessProbe: {}
     # path: /
     # port: ""
+    # httpHeaders:
+    # - name: Custom-Header
+    #   value: Awesome
     # failureThreshold: 3
     # initialDelaySeconds: 0
     # periodSeconds: 10
@@ -38,6 +41,9 @@ deploymentContainer:
   readinessProbe: {}
     # path: /
     # port: ""
+    # httpHeaders:
+    # - name: Custom-Header
+    #   value: Awesome
     # failureThreshold: 3
     # initialDelaySeconds: 0
     # periodSeconds: 10
@@ -46,6 +52,9 @@ deploymentContainer:
   startupProbe: {}
     # path: /
     # port: ""
+    # httpHeaders:
+    # - name: Custom-Header
+    #   value: Awesome
     # failureThreshold: 3
     # initialDelaySeconds: 0
     # periodSeconds: 10


### PR DESCRIPTION
**Ticket**
[SRE-3115](https://demoforthedaves.atlassian.net/browse/SRE-3115)

**Ticket and brief summary**
- Add http headers for liveness/readiness/startup probes

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[SRE-3115]: https://demoforthedaves.atlassian.net/browse/SRE-3115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ