### PR TITLE
Adding some default to job chart

### DIFF
--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5-beta.2
+version: 0.1.5-beta.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -37,18 +37,18 @@ imagePullSecrets: []
 # schedule timezone is UTC
 schedule: "* 0 * * *"
 suspend: false
-failedJobsHistoryLimit: ""
-successfulJobsHistoryLimit: ""
+failedJobsHistoryLimit: "1"
+successfulJobsHistoryLimit: "3"
 # The optional startingDeadlineSeconds field indicates the maximum number of seconds 
 # the CronJob can take to start if it misses its scheduled time for any reason. Missed CronJobs are considered failures.
-startingDeadlineSeconds: ""
+startingDeadlineSeconds: "600"
 # The optional spec.concurrencyPolicy field specifies how to treat concurrent executions of a Job created by the CronJob controller.
 # If you do not set a value, multiple concurrent Jobs are allowed by default. Accepts the following values: Allow, Forbid, Replace
-concurrencyPolicy: ""
+concurrencyPolicy: "Forbid"
 ###
 
-backoffLimit: ""
-ttlSecondsAfterFinished: ""
+backoffLimit: "1"
+ttlSecondsAfterFinished: "3600"
 activeDeadlineSeconds: ""
 
 restartPolicy: "OnFailure"


### PR DESCRIPTION
Adding default to job chart to help debugging, prevent concurrency and prevent execution when updating schedule