### PR TITLE
Update tekton-deployer role permissions

### DIFF
--- a/charts/tekton-common/Chart.yaml
+++ b/charts/tekton-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tekton-common
 description: A Helm chart with common resources to run Tekton pipelines in a namespace
 type: application
-version: 0.0.1-beta.1
+version: 0.0.1-beta.2

--- a/charts/tekton-common/templates/rbac.yaml
+++ b/charts/tekton-common/templates/rbac.yaml
@@ -42,6 +42,9 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelines", "pipelineresources"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Add permissions, so that a Tekton task can run another pipeline.