### PR TITLE
Add pods get permissions to tekton-deployer

### DIFF
--- a/charts/tekton-common/Chart.yaml
+++ b/charts/tekton-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tekton-common
 description: A Helm chart with common resources to run Tekton pipelines in a namespace
 type: application
-version: 0.0.1-beta.3
+version: 0.0.1-beta.4

--- a/charts/tekton-common/templates/rbac.yaml
+++ b/charts/tekton-common/templates/rbac.yaml
@@ -45,6 +45,9 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["pipelines", "pipelineresources", "taskruns"]
     verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This allows for the logs to display when running a pipeline using the tkn binary in a Tekton task.