### PR TITLE
Add permissions to tekton-deployer role

### DIFF
--- a/charts/tekton-common/Chart.yaml
+++ b/charts/tekton-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tekton-common
 description: A Helm chart with common resources to run Tekton pipelines in a namespace
 type: application
-version: 0.0.1-beta.4
+version: 0.0.1-beta.5

--- a/charts/tekton-common/templates/rbac.yaml
+++ b/charts/tekton-common/templates/rbac.yaml
@@ -43,11 +43,11 @@ rules:
     resources: ["pipelineruns"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["tekton.dev"]
-    resources: ["pipelines", "pipelineresources", "taskruns"]
-    verbs: ["get", "list"]
+    resources: ["pipelines", "pipelineresources", "taskruns", "runs"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get"]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This allows for a Tekton task to run a pipeline and stream the logs.