### PR TITLE
[DPE-341] - add: Slack secret for Tekton

### DIFF
--- a/charts/tekton-common/templates/secrets-slack.yaml
+++ b/charts/tekton-common/templates/secrets-slack.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: secrets-slack
+  name: slack-secrets
 spec:
   refreshInterval: 2h
   secretStoreRef:

--- a/charts/tekton-common/templates/secrets-slack.yaml
+++ b/charts/tekton-common/templates/secrets-slack.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: secrets-slack
+spec:
+  refreshInterval: 2h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: tekton-secret-store
+  target:
+    name: slack-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: SLACK_BOT_TOKEN
+      remoteRef:
+        key: slack_bot_sre_webhook


### PR DESCRIPTION
**Ticket**
[DPE-341](https://demoforthedaves.atlassian.net/browse/DPE-341)

**Ticket and brief summary**
add: Slack secret for Tekton

This secret contains the Slack bot token to use the Slack API

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[DPE-341]: https://demoforthedaves.atlassian.net/browse/DPE-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ