### PR TITLE
Enabling options for topologySpreadConstraints

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4-beta
+version: 0.8.4-beta.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -66,14 +66,16 @@ spec:
           maxSkew: {{ .Values.topologySpreadConstraints.zone.maxSkew }}
           whenUnsatisfiable: {{ .Values.topologySpreadConstraints.zone.whenUnsatisfiable }}
           labelSelector:
-            {{- include "common.selectorLabels" . | nindent 12 }}
+            matchLabels:
+              {{- include "common.selectorLabels" . | nindent 14 }}
         {{- end }}
         {{- if .Values.topologySpreadConstraints.node.enabled }}
         - topologyKey: {{ .Values.topologySpreadConstraints.node.topologyKey }}
           maxSkew: {{ .Values.topologySpreadConstraints.node.maxSkew }}
           whenUnsatisfiable: {{ .Values.topologySpreadConstraints.node.whenUnsatisfiable }}
           labelSelector:
-            {{- include "common.selectorLabels" . | nindent 12 }}
+            matchLabels:
+              {{- include "common.selectorLabels" . | nindent 14 }}
         {{- end }}
       {{- end }}
       {{- if .Values.initContainer.enabled }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -59,6 +59,23 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or (.Values.topologySpreadConstraints.zone.enabled) (.Values.topologySpreadConstraints.node.enabled) }}
+      topologySpreadConstraints:
+        {{- if .Values.topologySpreadConstraints.zone.enabled }}
+        - topologyKey: {{ .Values.topologySpreadConstraints.zone.topologyKey }}
+          maxSkew: {{ .Values.topologySpreadConstraints.zone.maxSkew }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.zone.whenUnsatisfiable }}
+          labelSelector:
+            {{- include "common.selectorLabels" . | nindent 12 }}
+        {{- end }}
+        {{- if .Values.topologySpreadConstraints.node.enabled }}
+        - topologyKey: {{ .Values.topologySpreadConstraints.node.topologyKey }}
+          maxSkew: {{ .Values.topologySpreadConstraints.node.maxSkew }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.node.whenUnsatisfiable }}
+          labelSelector:
+            {{- include "common.selectorLabels" . | nindent 12 }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.initContainer.enabled }}
       initContainers:
         - name: {{ .Values.initContainer.name }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 # Used for NODE_ENV and DD_ENV
 environment: staging
@@ -401,3 +401,19 @@ podSelectorLabelsOverride: {}
 #  to properly tag the team and environment
 
 additionalLabels: {}
+
+# This section enables by default the topologySpreadConstraits to spread same deployment pods to multiple nodes
+# and multiple AZ when possible, rules are soft enforced by default.
+# The next are the only values that can be edited, labelSelector are set by the template.
+
+topologySpreadConstraints:
+  zone:
+    enabled: true
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+  node:
+    enabled: true
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION
PR to 
- enable by default the use of topologySpreadConstraints to spread pod of the same deployment across nodes and AZs
- Set default replicas to 2 pods if not overridden by the values file


Currently, only the following parameters can be modified, selectorLabes are populated by the templating system

```
topologySpreadConstraints:
  zone:
    enabled: true
    maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: ScheduleAnyway
  node:
    enabled: true
    maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: ScheduleAnyway

```
 
    
diff for a deployment using this version

```

--- control.yaml	2023-07-18 18:32:29
+++ test4.yaml	2023-07-18 19:11:32
@@ -5,7 +5,7 @@
 metadata:
   name: financier
   labels:
-    helm.sh/chart: financier-0.8.4-beta
+    helm.sh/chart: financier-0.8.4-beta.1
     app.kubernetes.io/name: financier
     app.kubernetes.io/instance: financier
     app.kubernetes.io/version: "1.17.0"
@@ -21,7 +21,7 @@
 metadata:
   name: financier-customconfig
   labels:
-    helm.sh/chart: financier-0.8.4-beta
+    helm.sh/chart: financier-0.8.4-beta.1
     app.kubernetes.io/name: financier
     app.kubernetes.io/instance: financier
     app.kubernetes.io/version: "1.17.0"
@@ -39,7 +39,7 @@
   name: financier
   annotations:
   labels:
-    helm.sh/chart: financier-0.8.4-beta
+    helm.sh/chart: financier-0.8.4-beta.1
     app.kubernetes.io/name: financier
     app.kubernetes.io/instance: financier
     app.kubernetes.io/version: "1.17.0"
@@ -65,7 +65,7 @@
   labels:
     tags.datadoghq.com/version: "latest"
     run: financier
-    helm.sh/chart: financier-0.8.4-beta
+    helm.sh/chart: financier-0.8.4-beta.1
     app.kubernetes.io/name: financier
     app.kubernetes.io/instance: financier
     app.kubernetes.io/version: "1.17.0"
@@ -73,7 +73,7 @@
     env: staging
     team: sre
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: financier
@@ -100,6 +100,19 @@
         runAsGroup: 1000
         runAsUser: 1000
       terminationGracePeriodSeconds:
+      topologySpreadConstraints:
+        - topologyKey: topology.kubernetes.io/zone
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: financier
+              app.kubernetes.io/instance: financier
+        - topologyKey: kubernetes.io/hostname
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: financier
+              app.kubernetes.io/instance: financier
       containers:
         - name: financier
           securityContext:
@@ -165,7 +178,7 @@
```
