### PR TITLE
Adding fix for use of  custom and existing SA on custom workflows chart

### DIFF
--- a/charts/workflow/Chart.yaml
+++ b/charts/workflow/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1-beta.1
+version: 0.1.1-beta.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/workflow/templates/role.yaml
+++ b/charts/workflow/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if or .Values.serviceAccount.create .Values.serviceAccount.addRBAC -}}
-{{- if or (ne .Values.serviceAccount.name "workflows") (.Values.serviceAccount.existingNameSA) -}}
+{{- if ne .Values.serviceAccount.name "workflows" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/workflow/templates/role.yaml
+++ b/charts/workflow/templates/role.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.serviceAccount.create -}}
-{{- if ne .Values.serviceAccount.name "workflows" -}}
+{{- if or .Values.serviceAccount.create .Values.serviceAccount.addRBAC -}}
+{{- if or (ne .Values.serviceAccount.name "workflows") (.Values.serviceAccount.existingNameSA) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/workflow/templates/rolebinding.yaml
+++ b/charts/workflow/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if or .Values.serviceAccount.create .Values.serviceAccount.addRBAC -}}
-{{- if or (ne .Values.serviceAccount.name "workflows") (.Values.serviceAccount.existingNameSA) -}}
+{{- if ne .Values.serviceAccount.name "workflows" -}}
 apiVersion: rbacmanager.reactiveops.io/v1beta1
 kind: RBACDefinition
 metadata:

--- a/charts/workflow/templates/rolebinding.yaml
+++ b/charts/workflow/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.serviceAccount.create -}}
-{{- if ne .Values.serviceAccount.name "workflows" -}}
+{{- if or .Values.serviceAccount.create .Values.serviceAccount.addRBAC -}}
+{{- if or (ne .Values.serviceAccount.name "workflows") (.Values.serviceAccount.existingNameSA) -}}
 apiVersion: rbacmanager.reactiveops.io/v1beta1
 kind: RBACDefinition
 metadata:

--- a/charts/workflow/templates/workflowtemplate.yaml
+++ b/charts/workflow/templates/workflowtemplate.yaml
@@ -17,7 +17,7 @@ spec:
   podDisruptionBudget:
     minAvailable: "{{ .Values.podDisruptionBudget.minAvailable }}"
   {{- end }}
-  serviceAccountName: "{{ .Values.serviceAccount.name }}"
+  serviceAccountName: {{ include "common.serviceAccountName" . }}
   {{- with .Values.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 4 }}

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -38,8 +38,12 @@ serviceAccount:
   workloadIdentitySA: ""
   # Specifies whether an existing service account will be used
   # Make sure you set serviceAccount.create:false when using this option
+  # Verify if you need serviceAccount.addRBAC:true when using this option
   # Dynamic environments will use of this one
   existingNameSA: ""
+  # Adds the necesary RBAC roles to an existent SA, this needs to be used only once per SA
+  # only if the SA was originally defined by an regultar deployment
+  addRBAC: false
 
 # You can add a cloudsql proxy template by enabling this option.
 # This is similar to migrations detifnitions.

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -29,7 +29,7 @@ serviceAccount:
   # If you are using a complete new SA, change the name and set true to create and addRBAC
   name: workflows
   # Specifies whether a service account should be created
-  # This should be set to false if you are re-using an excisting SA
+  # This should be set to false if you are re-using an existing SA
   create: false
   # Adds the necesary RBAC roles for the SA, this needs to be used only once per SA
   # if you are using an SA originally created by a deployment with common chart, this should be set to true

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -24,26 +24,26 @@ sidecars: []
 #   args: ["while true; do echo hello world!!!; sleep 10; done"]
 
 serviceAccount:
-  # At this moment all workflows run with this specific
-  # Please don't change it until a version that supports custom service account is released
+  # Specify the name of the SA to use, defaults to workflows
+  # You can use an already defined SA
+  # If you are using a complete new SA, change the name and set true to create and addRBAC
   name: workflows
   # Specifies whether a service account should be created
-  # This flag will take no effect if SA is named workflows
+  # This should be set to false if you are re-using an excisting SA
   create: false
+  # Adds the necesary RBAC roles for the SA, this needs to be used only once per SA
+  # if you are using an SA originally created by a deployment with common chart, this should be set to true
+  addRBAC: false
+
   # Annotations to add to the service account
+  # Only if serviceAccount.create:true
   annotations: {}
   # IAM workload idenitity binding name
   # If not set and serviceAccount.create:true, a name is generated using Release.Name
   # If Release.Name is bigger than 30 characteres use this variable to overwrite it with something shorter to identify this workload
+  # Only if serviceAccount.create:true
   workloadIdentitySA: ""
-  # Specifies whether an existing service account will be used
-  # Make sure you set serviceAccount.create:false when using this option
-  # Verify if you need serviceAccount.addRBAC:true when using this option
-  # Dynamic environments will use of this one
-  existingNameSA: ""
-  # Adds the necesary RBAC roles to an existent SA, this needs to be used only once per SA
-  # only if the SA was originally defined by an regultar deployment
-  addRBAC: false
+
 
 # You can add a cloudsql proxy template by enabling this option.
 # This is similar to migrations detifnitions.


### PR DESCRIPTION
**BREAKING CHANGES:**

Removes  `serviceAccount.existingNameSA`
removes the extra directive in favor of the combination of 
```
serviceAccount.name: this-sa-already-exist
serviceAccount.create: false
```

Changes the behavior on creating and re-using existing Service Accounts (SA),  supports the next 3 scenarios:

1 - Use the `workflows` SA and take no other action, this is the **default** scenario, the SA should already be defined if your common chart deployment has the migration template enabled. 
```
  serviceAccount:
    name: workflow
    create: false
    addRBAC: false
```

2- Re-use an SA from a different deployment, ie. overdraft uses the `overdraft`  SA, the SA object already exists in the cluster, and just the RBAC needs to be added.
You will also need to add the necessary log bucket permissions with terraform
```
  serviceAccount:
    name: overdraft
    create: false
    addRBAC: true
``` 

3-  Create a brand-new SA to be used by the workflows runner
You will also need to add the necessary log bucket permissions and other app permissions with terraform
```
  serviceAccount:
    name: brand-new-sa
    create: true
    addRBAC: true ( this will be overridden by create:true )
```
