### PR TITLE
Adding memory request and limits to cloudsql-proxy sidecar

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6-beta.3
+version: 0.8.6-beta.4
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -350,7 +350,10 @@ cloudsqlProxy:
   # command: ['/cloud_sql_proxy','--dir=/cloudsql','-instances=project_name:region:instance_name']
   resources:
     requests:
-      cpu: '100m'
+      cpu: 50m
+      memory: 25Mi
+    limits:
+      memory: 256Mi
   lifecycle:
     preStop:
       exec:


### PR DESCRIPTION
Changelog:
Common chart
- Decreases the default CPU request from 100m to 50m to cloudsql-proxy
- Add default memory request of 25Mi to cloudsql-proxy
- Add default memory limit of 256Mi to cloudsql-proxy


New default requests and limits based on VPA and GKE metrics recommendations:
```
      Container Name:  cloudsql-proxy
      Lower Bound:
        Cpu:     8m
        Memory:  12582912
      Target:
        Cpu:     15m
        Memory:  13631488
      Uncapped Target:
        Cpu:     15m
        Memory:  13631488
      Upper Bound:
        Cpu:     15m
        Memory:  13631488
```