### PR TITLE
[SRE-4508] Add initContainer secret fetch stage to validate the intended secrets

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6
+version: 0.8.7-beta.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -79,14 +79,23 @@ spec:
               {{- include "common.selectorLabels" . | nindent 14 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.initContainer.enabled }}
+      {{- if (or .Values.initContainer.enabled .Values.failOnMissingLocalSecrets.enabled) }}
       initContainers:
+        {{- if .Values.initContainer.enabled }}
         - name: {{ .Values.initContainer.name }}
           image: {{ .Values.initContainer.image }}
           command: {{ toYaml .Values.initContainer.command | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+        {{- end }}
+        {{- if .Values.failOnMissingLocalSecrets.enabled }}
+        - name: check-local-secrets
+          {{/* Reusing the main container's image is done on purpose */}}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: {{ toYaml .Values.failOnMissingLocalSecrets.secretsFetch.command | nindent 12}}
+          args: {{ toYaml .Values.failOnMissingLocalSecrets.secretsFetch.args | nindent 12}}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ include "common.name" . }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -481,3 +481,19 @@ customVolumes:
   #     mountPath: /www/somepath/
   #     subPath: ""
   #     readOnly: true
+
+# If `failOnMissingLocalSecrets` is enabled, an initContainer will try to
+# fetch the secrets.
+#
+# If `local-secrets`, which is what powers the `secrets:fetch` target returns
+# an error status, the rollout of a new replicaset will halt and that will
+# buy us time to either define the missing secret or remove it as a
+# requirement without bringing the whole deployment down in the process.
+#
+# Since not all the `service-template` derived deployments use the same command
+# to fetch secrets, that field is customizable to fit the needs of all.
+failOnMissingLocalSecrets:
+  enabled: false
+  secretsFetch:
+    command: ["yarn"]
+    args: ["secrets:fetch"]


### PR DESCRIPTION
**Ticket**
[SRE-4508](https://demoforthedaves.atlassian.net/browse/SRE-4508)

**Ticket and brief summary**
- Add initContainer secret fetch stage to validate the intended secrets have been populated before doing a complete replicaset rollout

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[SRE-4508]: https://demoforthedaves.atlassian.net/browse/SRE-4508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ