### PR TITLE
Move to cloud-sql-proxy v2 and add probes by default

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.7
+version: 0.8.8-beta.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -95,3 +95,17 @@ Either gcr.io/cloudsql-docker/gce-proxy:1.* or with gcr.io/cloud-sql-connectors/
 {{- fail "cloudsqlProxyVersion is not supported" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create common.instanceConnectionName depending on .Values.cloudsqlProxy.instanceConnectionName
+or .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName
+*/}}
+{{- define "common.instanceConnectionName" -}}
+{{- if .Values.cloudsqlProxy.instanceConnectionName }}
+{{- printf .Values.cloudsqlProxy.instanceConnectionName }}
+{{- else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName }}
+{{- printf .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName }}
+{{- else }}
+{{- fail "instanceConnectionName is not set" }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -80,3 +80,18 @@ Name for the custom config configmap.
 {{- define "common.customConfig.name" -}}
 {{ .Values.customConfig.name | default (print (include "common.name" .) "-customconfig") }}
 {{- end -}}
+
+
+{{/*
+Create common.cloudsqlProxyVersion depending on .Values.cloudsqlProxy.image.repository depending on the image used.
+Either gcr.io/cloudsql-docker/gce-proxy:1.* or with gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.*
+*/}}
+{{- define "common.cloudsqlProxyVersion" -}}
+{{- if hasPrefix "gcr.io/cloudsql-docker/gce-proxy:1" .Values.cloudsqlProxy.image.repository }}
+{{- printf "v1" }}
+{{- else if hasPrefix "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2" .Values.cloudsqlProxy.image.repository }}
+{{- printf "v2" }}
+{{- else }}
+{{- fail "cloudsqlProxyVersion is not supported" }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -310,7 +310,7 @@ spec:
             {{- toYaml .Values.cloudsqlProxy.readinessProbe | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.cloudsqlProxy.startupProbe | nindent 12 }}
-          livecycle:
+          lifecycle:
             {{- toYaml .Values.cloudsqlProxy.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.cloudsqlProxy.resources | nindent 12 }}
@@ -318,7 +318,6 @@ spec:
             {{- toYaml .Values.cloudsqlProxy.command | nindent 12 }}
           {{- if .Values.cloudsqlProxy.instanceConnectionName }}
           args:
-            - "--structured-logs"
             - "--private-ip"
             - "{{ .Values.cloudsqlProxy.instanceConnectionName }}?unix-socket-path=/cloudsql/{{ .Values.cloudsqlProxy.instanceConnectionName }}"
           {{- else }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -7,6 +7,7 @@
 .Values.customConfig.enabled
 .Values.customVolumes.enabled
 ) -}}
+{{- $sqlProxyVersion := include "common.cloudsqlProxyVersion" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -302,6 +303,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.cloudsqlProxy.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ( eq $sqlProxyVersion "v2" ) }}
           ports:
             {{- toYaml .Values.cloudsqlProxy.ports | nindent 12 }}
           livenessProbe:
@@ -312,20 +314,33 @@ spec:
             {{- toYaml .Values.cloudsqlProxy.startupProbe | nindent 12 }}
           lifecycle:
             {{- toYaml .Values.cloudsqlProxy.lifecycle | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.cloudsqlProxy.resources | nindent 12 }}
+          {{- if and ( eq $sqlProxyVersion "v1" ) ( .Values.cloudsqlProxy.instanceConnectionName ) ( not .Values.cloudsqlProxy.command ) }}
+          command:
+            - "/cloud_sql_proxy"
+            - "--dir=/cloudsql"
+            - "-log_debug_stdout=true"
+            - "-verbose=false"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ .Values.cloudsqlProxy.instanceConnectionName }}"
+          {{- else if and ( eq $sqlProxyVersion "v1" ) (.Values.cloudsqlProxy.command) }}
           command:
             {{- toYaml .Values.cloudsqlProxy.command | nindent 12 }}
-          {{- if .Values.cloudsqlProxy.instanceConnectionName }}
+          {{- end }}
+          {{- if and (eq $sqlProxyVersion "v2") (.Values.cloudsqlProxy.instanceConnectionName) (not .Values.cloudsqlProxy.args) }}
           args:
             - "--private-ip"
             - "{{ .Values.cloudsqlProxy.instanceConnectionName }}?unix-socket-path=/cloudsql/{{ .Values.cloudsqlProxy.instanceConnectionName }}"
-          {{- else }}
+          {{- else if and ( eq $sqlProxyVersion "v2" ) (.Values.cloudsqlProxy.args) }}
           args:
             {{- toYaml .Values.cloudsqlProxy.args | nindent 12 }}
           {{- end }}
+          {{ if and ( eq $sqlProxyVersion "v2" ) (.Values.cloudsqlProxy.env) }}
           env:
             {{- toYaml .Values.cloudsqlProxy.env | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: {{ .Values.cloudsqlProxy.volume }}
               mountPath: /{{ .Values.cloudsqlProxy.volume }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -302,22 +302,34 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.cloudsqlProxy.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- toYaml .Values.cloudsqlProxy.ports | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.cloudsqlProxy.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.cloudsqlProxy.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.cloudsqlProxy.startupProbe | nindent 12 }}
+          livecycle:
+            {{- toYaml .Values.cloudsqlProxy.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.cloudsqlProxy.resources | nindent 12 }}
-          {{- if .Values.cloudsqlProxy.command }}
           command:
             {{- toYaml .Values.cloudsqlProxy.command | nindent 12 }}
+          {{- if .Values.cloudsqlProxy.instanceConnectionName }}
+          args:
+            - "--structured-logs"
+            - "--private-ip"
+            - "{{ .Values.cloudsqlProxy.instanceConnectionName }}?unix-socket-path=/cloudsql/{{ .Values.cloudsqlProxy.instanceConnectionName }}"
+          {{- else }}
+          args:
+            {{- toYaml .Values.cloudsqlProxy.args | nindent 12 }}
           {{- end }}
+          env:
+            {{- toYaml .Values.cloudsqlProxy.env | nindent 12 }}
           volumeMounts:
             - name: {{ .Values.cloudsqlProxy.volume }}
               mountPath: /{{ .Values.cloudsqlProxy.volume }}
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/sh
-                  - '-c'
-                  - /bin/sleep 30
           {{- end }}
 
       {{- if $hasVolumes }}{{/* begin volumes */}}

--- a/charts/common/templates/workflowtemplate.yaml
+++ b/charts/common/templates/workflowtemplate.yaml
@@ -45,7 +45,7 @@ spec:
       limit: 3
     container:
       image: gcr.io/cloudsql-docker/gce-proxy:latest
-      command: ["/cloud_sql_proxy","-instances={{ required `"A valid instanceUrl is required!"` .Values.cloudsqlProxy.instanceConnectionName }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
+      command: ["/cloud_sql_proxy","-instances={{ include "common.instanceConnectionName" . }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
       readinessProbe:
         tcpSocket:
           port: {{ .Values.cloudsqlProxy.migrationTemplate.port }}

--- a/charts/common/templates/workflowtemplate.yaml
+++ b/charts/common/templates/workflowtemplate.yaml
@@ -45,7 +45,7 @@ spec:
       limit: 3
     container:
       image: gcr.io/cloudsql-docker/gce-proxy:latest
-      command: ["/cloud_sql_proxy","-instances={{ required `"A valid instanceUrl is required!"` .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
+      command: ["/cloud_sql_proxy","-instances={{ required `"A valid instanceUrl is required!"` .Values.cloudsqlProxy.instanceConnectionName }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
       readinessProbe:
         tcpSocket:
           port: {{ .Values.cloudsqlProxy.migrationTemplate.port }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -84,14 +84,18 @@ deploymentContainer:
   # customStartupProbe that overrides the default one
   customStartupProbe: {}
 
-  terminationGracePeriodSeconds: 30
-
   ## If you want to add a preStop hooks, or any other lifecycles to your
   ## deployment, you can define them here:
   #lifecycle:
-  #preStop:
-  #  exec:
-  #    command: ["/bin/sh", "-c", "echo 'PreStop hook'"]
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "echo 'PreStop hook'"]
+
+# terminationGracePeriodSeconds is the time to wait before forcefully terminating a pod
+# after a SIGTERM signal is sent to the container. If the preStop hook is used, this
+# value should be set to a higher value than the preStop hook timeout.
+# Setting default 1 second higher than the preStop most Dave's apps have 30 seconds
+terminationGracePeriodSeconds: 31
 
 image:
   repository: nginx
@@ -357,8 +361,8 @@ cloudsqlProxy:
   # Takes precedence over args and command
   # instanceConnectionName: project_name:region:instance_name
   # Args is only available for version gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.*
+  # The following args are used by default if you don't define them
   # args:
-  #   - "--structured-logs"
   #   - "--private-ip"
   #   - "project_name:region:instance_name?unix-socket-path=/cloudsql/project_name:region:instance_name"
   # Deprecated: The following option is available to avoid breaking changes to version gcr.io/cloudsql-docker/gce-proxy:gce-proxy:1.*
@@ -383,29 +387,25 @@ cloudsqlProxy:
       value: "9801"
     - name: CSQL_PROXY_HTTP_ADDRESS
       value: 0.0.0.0
-    # Configure the proxy to exit gracefully when sent a k8s configuration
-    # file.
-    - name: CSQL_PROXY_EXIT_ZERO_ON_SIGTERM
-      value: "true"
+    - name: CSQL_PROXY_ADMIN_PORT
+      value: "9092"
     # Enable the admin api server (which only listens for local connections)
     # and enable the /quitquitquit endpoint. This allows other pods
     # to shut down the proxy gracefully when they are ready to exit.
     - name: CSQL_PROXY_QUITQUITQUIT
       value: "true"
-    - name: CSQL_PROXY_ADMIN_PORT
-      value: "9092"
-    # Enable structured logging with LogEntry format
     - name: CSQL_PROXY_STRUCTURED_LOGS
       value: "true"
-  # Configure kubernetes to call the /quitquitquit endpoint on the
-  # admin server before sending SIGTERM to the proxy before stopping
-  # the pod. This will give the proxy more time to gracefully exit.
+  # The lifecycle.preStop is used to delay the pod termination to allow the
+  # remaining connections from main container to exit gracefully.
   lifecycle:
     preStop:
-      httpGet:
-        path: /quitquitquit
-        port: 9092
-        scheme: HTTP
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - /bin/sleep 30
+
   # The /startup probe returns OK when the proxy is ready to receive
   # connections from the application. In this example, k8s will check
   # once a second for 60 seconds.
@@ -471,7 +471,7 @@ cloudsqlProxy:
     command: /opt/app/node_modules/.bin/knex --knexfile knexfile.js migrate:latest
     # Image tag used for migration template along with image.repository. This can always be replaced at runtime in Argo Workflows
     tag: latest
-    # Instance connection name should be defined with custom values of your CloudSQL instance
+    # Deprecated: We use cloudsqlProxy.instanceConnectionName instead, no need to define it at the migrationTemplate level
     #instanceConnectionName: project_name:region:instance_name
     port: 3306
     secretName: migration

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -352,20 +352,118 @@ cloudsqlProxy:
   enabled: false
   name: cloudsql-proxy
   image:
-    repository: gcr.io/cloudsql-docker/gce-proxy:1.31.1-alpine
+    repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4-alpine
+  # instanceConnectionName only available after common-chart 0.8.8*
+  # Takes precedence over args and command
+  # instanceConnectionName: project_name:region:instance_name
+  # Args is only available for version gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.*
+  # args:
+  #   - "--structured-logs"
+  #   - "--private-ip"
+  #   - "project_name:region:instance_name?unix-socket-path=/cloudsql/project_name:region:instance_name"
+  # Deprecated: The following option is available to avoid breaking changes to version gcr.io/cloudsql-docker/gce-proxy:gce-proxy:1.*
   # Command should be defined with the command and custom values of your CloudSQL instance
   # command: ['/cloud_sql_proxy','--dir=/cloudsql','-instances=project_name:region:instance_name']
+
   resources:
     requests:
       cpu: 50m
       memory: 25Mi
     limits:
       memory: 256Mi
+  volume: cloudsql
+  env:
+    # Enable HTTP healthchecks on port 9801. This enables /liveness,
+    # /readiness and /startup health check endpoints. Allow connections
+    # listen for connections on any interface (0.0.0.0) so that the
+    # k8s management components can reach these endpoints.
+    - name: CSQL_PROXY_HEALTH_CHECK
+      value: "true"
+    - name: CSQL_PROXY_HTTP_PORT
+      value: "9801"
+    - name: CSQL_PROXY_HTTP_ADDRESS
+      value: 0.0.0.0
+    # Configure the proxy to exit gracefully when sent a k8s configuration
+    # file.
+    - name: CSQL_PROXY_EXIT_ZERO_ON_SIGTERM
+      value: "true"
+    # Enable the admin api server (which only listens for local connections)
+    # and enable the /quitquitquit endpoint. This allows other pods
+    # to shut down the proxy gracefully when they are ready to exit.
+    - name: CSQL_PROXY_QUITQUITQUIT
+      value: "true"
+    - name: CSQL_PROXY_ADMIN_PORT
+      value: "9092"
+    # Enable structured logging with LogEntry format
+    - name: CSQL_PROXY_STRUCTURED_LOGS
+      value: "true"
+  # Configure kubernetes to call the /quitquitquit endpoint on the
+  # admin server before sending SIGTERM to the proxy before stopping
+  # the pod. This will give the proxy more time to gracefully exit.
   lifecycle:
     preStop:
-      exec:
-        command: ['/bin/sh','-c','/bin/sleep 30']
-  volume: cloudsql
+      httpGet:
+        path: /quitquitquit
+        port: 9092
+        scheme: HTTP
+  # The /startup probe returns OK when the proxy is ready to receive
+  # connections from the application. In this example, k8s will check
+  # once a second for 60 seconds.
+  # We strongly recommend adding a startup probe to the proxy sidecar
+  # container. This will ensure that service traffic will be routed to
+  # the pod only after the proxy has successfully started.
+  startupProbe:
+    failureThreshold: 60
+    httpGet:
+      path: /startup
+      port: 9801
+      scheme: HTTP
+    periodSeconds: 1
+    successThreshold: 1
+    timeoutSeconds: 10
+  # The /liveness probe returns OK as soon as the proxy application has
+  # begun its startup process and continues to return OK until the
+  # process stops.
+  # We recommend adding a liveness probe to the proxy sidecar container.
+  livenessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /liveness
+      port: 9801
+      scheme: HTTP
+    # The probe will be checked every 10 seconds.
+    periodSeconds: 10
+    # Number of times the probe is allowed to fail before the transition
+    # from healthy to failure state.
+    # If periodSeconds = 60, 5 tries will result in five minutes of
+    # checks. The proxy starts to refresh a certificate five minutes
+    # before its expiration. If those five minutes lapse without a
+    # successful refresh, the liveness probe will fail and the pod will be
+    # restarted.
+    successThreshold: 1
+    # The probe will fail if it does not respond in 10 seconds
+    timeoutSeconds: 10
+  # The /readiness probe returns OK when the proxy can establish
+  # a new connections to its databases.
+  # Please use the readiness probe to the proxy sidecar with caution.
+  # An improperly configured readiness probe can cause unnecessary
+  # interruption to the application. See README.md for more detail.
+  readinessProbe:
+    httpGet:
+      path: /readiness
+      port: 9801
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 10
+    # Number of times the probe must report success to transition from failure to healthy state.
+    # Defaults to 1 for readiness probe.
+    successThreshold: 1
+    failureThreshold: 6
+  # Declare the HTTP Port so that k8s components can reach the
+  # metrics and health check endpoints.
+  ports:
+  - containerPort: 9801
+    protocol: TCP
   # This section creates a template in Argo Workflows that is used for sql migrations
   migrationTemplate:
     enabled: false


### PR DESCRIPTION
https://demoforthedaves.atlassian.net/browse/SRE-4700
- In order for CloudSQL proxies pass Kyverno policies the following changes are implemented in this new version.
- Move to cloud-sql-proxy v2 as default for common-charts (deployments/sidecar)
- This would ensure K8s monitor the health of the sidecar:
  - readinessProbe
  - livenessProbe
  - startupProbe
- Simplify definition of the cloudsqlProxy in values.yaml it can now be defined as
```
  cloudsqlProxy:
    enabled: true
    instanceConnectionName: internal-1-4825:us-central1:staging-2
    migrationTemplate:
      enabled: true
```
- If this version goes well sets the path to apply this changes for the jobs (cronjob) chart
- Ref: 
  - https://github.com/GoogleCloudPlatform/cloud-sql-proxy
  - https://github.com/GoogleCloudPlatform/cloud-sql-proxy/tree/main/examples/k8s-health-check