### PR TITLE
Add some logic to find instanceConnectionName and switch to quiet logs

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.8-beta.1
+version: 0.8.8-beta.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -95,3 +95,17 @@ Either gcr.io/cloudsql-docker/gce-proxy:1.* or with gcr.io/cloud-sql-connectors/
 {{- fail "cloudsqlProxyVersion is not supported" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create common.instanceConnectionName depending on .Values.cloudsqlProxy.instanceConnectionName
+or .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName
+*/}}
+{{- define "common.instanceConnectionName" -}}
+{{- if .Values.cloudsqlProxy.instanceConnectionName }}
+{{- printf .Values.cloudsqlProxy.instanceConnectionName }}
+{{- else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName }}
+{{- printf .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName }}
+{{- else }}
+{{- fail "instanceConnectionName is not set" }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -102,7 +102,8 @@ else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName
 else if try to extract it from the .Values.cloudsqlProxy.command list
 else if try to extract it from the .Values.cloudsqlProxy.args list
 else fail.
-This variable will be used in deployment.yaml and workflowtemplate.yaml and can be removed once all charts are on 0.8.8 or higher.
+This variable will be used in deployment.yaml and workflowtemplate.yaml it's a safer way to get the instanceConnectionName.
+Once all apps are using cloud sql proxy v2 this can be simplified.
 */}}
 {{- define "common.instanceConnectionName" -}}
   {{- if .Values.cloudsqlProxy.instanceConnectionName -}}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -130,6 +130,6 @@ Once all apps are using cloud sql proxy v2 this can be simplified.
     {{- end -}}
     {{- $instanceArg | regexFind "^[^?]+" | trim -}}
   {{- else -}}
-    {{- fail ".Values.cloudsqlProxy.instanceConnectionName|command|args are not set" -}}
+    {{- fail "Can't get instanceConnectionName in .Values.cloudsqlProxy.instanceConnectionName|command|args or properties not set" -}}
   {{- end -}}
 {{- end -}}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -98,14 +98,37 @@ Either gcr.io/cloudsql-docker/gce-proxy:1.* or with gcr.io/cloud-sql-connectors/
 
 {{/*
 Create common.instanceConnectionName depending on .Values.cloudsqlProxy.instanceConnectionName
-or .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName
+else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName
+else if try to extract it from the .Values.cloudsqlProxy.command list
+else if try to extract it from the .Values.cloudsqlProxy.args list
+else fail.
+This variable will be used in deployment.yaml and workflowtemplate.yaml and can be removed once all charts are on 0.8.8 or higher.
 */}}
 {{- define "common.instanceConnectionName" -}}
-{{- if .Values.cloudsqlProxy.instanceConnectionName }}
-{{- printf .Values.cloudsqlProxy.instanceConnectionName }}
-{{- else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName }}
-{{- printf .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName }}
-{{- else }}
-{{- fail "instanceConnectionName is not set" }}
-{{- end }}
-{{- end }}
+  {{- if .Values.cloudsqlProxy.instanceConnectionName -}}
+    {{- .Values.cloudsqlProxy.instanceConnectionName  -}}
+  {{- else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName -}}
+    {{- .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName  -}}
+  {{- else if .Values.cloudsqlProxy.command -}}
+    {{- $commandList := .Values.cloudsqlProxy.command -}}
+    {{- $instanceArg := "" -}}
+    {{- range $cmd := $commandList -}}
+      {{- if hasPrefix "-instances=" $cmd -}}
+        {{- $instanceArg = $cmd -}}
+      {{- end -}}
+    {{- end -}}
+    {{- trimPrefix "-instances=" $instanceArg }}
+  {{- else if .Values.cloudsqlProxy.args -}}
+    {{- $argsList := .Values.cloudsqlProxy.args -}}
+    {{- $instanceArg := "" -}}
+    {{- range $arg := $argsList -}}
+      {{- if not (hasPrefix "-" $arg) -}}
+        {{- $instanceArg = $arg -}}
+        {{- break -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $instanceArg | regexFind "^[^?]+" | trim -}}
+  {{- else -}}
+    {{- fail ".Values.cloudsqlProxy.instanceConnectionName|command|args are not set" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -309,6 +309,13 @@ spec:
             {{- toYaml .Values.cloudsqlProxy.ports | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.cloudsqlProxy.livenessProbe | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - /bin/sleep 30 && rm -f /cloudsql/{{ $sqlinstanceConnectionName }}
           readinessProbe:
             {{- toYaml .Values.cloudsqlProxy.readinessProbe | nindent 12 }}
           startupProbe:

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -333,6 +333,7 @@ spec:
           {{- if and (eq $sqlProxyVersion "v2") ( $sqlinstanceConnectionName ) (not .Values.cloudsqlProxy.args) }}
           args:
             - "--private-ip"
+            - "--quiet"
             - "{{ $sqlinstanceConnectionName }}?unix-socket-path=/cloudsql/{{ $sqlinstanceConnectionName }}"
           {{- else if and ( eq $sqlProxyVersion "v2" ) (.Values.cloudsqlProxy.args) }}
           args:

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -8,6 +8,7 @@
 .Values.customVolumes.enabled
 ) -}}
 {{- $sqlProxyVersion := include "common.cloudsqlProxyVersion" . -}}
+{{- $sqlinstanceConnectionName := include "common.instanceConnectionName" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -317,22 +318,22 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.cloudsqlProxy.resources | nindent 12 }}
-          {{- if and ( eq $sqlProxyVersion "v1" ) ( .Values.cloudsqlProxy.instanceConnectionName ) ( not .Values.cloudsqlProxy.command ) }}
+          {{- if and ( eq $sqlProxyVersion "v1" ) ( $sqlinstanceConnectionName ) ( not .Values.cloudsqlProxy.command ) }}
           command:
             - "/cloud_sql_proxy"
             - "--dir=/cloudsql"
             - "-log_debug_stdout=true"
             - "-verbose=false"
             - "-ip_address_types=PRIVATE"
-            - "-instances={{ .Values.cloudsqlProxy.instanceConnectionName }}"
+            - "-instances={{ $sqlinstanceConnectionName }}"
           {{- else if and ( eq $sqlProxyVersion "v1" ) (.Values.cloudsqlProxy.command) }}
           command:
             {{- toYaml .Values.cloudsqlProxy.command | nindent 12 }}
           {{- end }}
-          {{- if and (eq $sqlProxyVersion "v2") (.Values.cloudsqlProxy.instanceConnectionName) (not .Values.cloudsqlProxy.args) }}
+          {{- if and (eq $sqlProxyVersion "v2") ( $sqlinstanceConnectionName ) (not .Values.cloudsqlProxy.args) }}
           args:
             - "--private-ip"
-            - "{{ .Values.cloudsqlProxy.instanceConnectionName }}?unix-socket-path=/cloudsql/{{ .Values.cloudsqlProxy.instanceConnectionName }}"
+            - "{{ $sqlinstanceConnectionName }}?unix-socket-path=/cloudsql/{{ $sqlinstanceConnectionName }}"
           {{- else if and ( eq $sqlProxyVersion "v2" ) (.Values.cloudsqlProxy.args) }}
           args:
             {{- toYaml .Values.cloudsqlProxy.args | nindent 12 }}

--- a/charts/common/templates/workflowtemplate.yaml
+++ b/charts/common/templates/workflowtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $sqlinstanceConnectionName := include "common.instanceConnectionName" . -}}
 {{- if .Values.cloudsqlProxy.migrationTemplate.enabled -}}
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -45,7 +46,7 @@ spec:
       limit: 3
     container:
       image: gcr.io/cloudsql-docker/gce-proxy:latest
-      command: ["/cloud_sql_proxy","-instances={{ include "common.instanceConnectionName" . }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
+      command: ["/cloud_sql_proxy","-instances={{ $sqlinstanceConnectionName }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
       readinessProbe:
         tcpSocket:
           port: {{ .Values.cloudsqlProxy.migrationTemplate.port }}

--- a/charts/common/templates/workflowtemplate.yaml
+++ b/charts/common/templates/workflowtemplate.yaml
@@ -45,7 +45,7 @@ spec:
       limit: 3
     container:
       image: gcr.io/cloudsql-docker/gce-proxy:latest
-      command: ["/cloud_sql_proxy","-instances={{ required `"A valid instanceUrl is required!"` .Values.cloudsqlProxy.instanceConnectionName }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
+      command: ["/cloud_sql_proxy","-instances={{ include "common.instanceConnectionName" . }}=tcp:0.0.0.0:{{ .Values.cloudsqlProxy.migrationTemplate.port }}"]
       readinessProbe:
         tcpSocket:
           port: {{ .Values.cloudsqlProxy.migrationTemplate.port }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -364,6 +364,7 @@ cloudsqlProxy:
   # The following args are used by default if you don't define them
   # args:
   #   - "--private-ip"
+  #   - "--quiet"
   #   - "project_name:region:instance_name?unix-socket-path=/cloudsql/project_name:region:instance_name"
   # Deprecated: The following option is available to avoid breaking changes to version gcr.io/cloudsql-docker/gce-proxy:gce-proxy:1.*
   # Command should be defined with the command and custom values of your CloudSQL instance

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -356,17 +356,19 @@ cloudsqlProxy:
   enabled: false
   name: cloudsql-proxy
   image:
+    # As of 0.8.8* we are using CloudSQL Proxy v2 by default notice is a different repository
+    # Deprecated: repository: gcr.io/cloudsql-docker/gce-proxy:1.36.0-alpine
     repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4-alpine
   # instanceConnectionName only available after common-chart 0.8.8*
   # Takes precedence over args and command
   # instanceConnectionName: project_name:region:instance_name
-  # Args is only available for version gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.*
+  # args is only available for CloudSQL Proxy v2
   # The following args are used by default if you don't define them
   # args:
   #   - "--private-ip"
   #   - "--quiet"
   #   - "project_name:region:instance_name?unix-socket-path=/cloudsql/project_name:region:instance_name"
-  # Deprecated: The following option is available to avoid breaking changes to version gcr.io/cloudsql-docker/gce-proxy:gce-proxy:1.*
+  # Deprecated: The following option is available to avoid breaking changes in case you need to run CloudSQL Proxy v1 with custom command
   # Command should be defined with the command and custom values of your CloudSQL instance
   # command: ['/cloud_sql_proxy','--dir=/cloudsql','-instances=project_name:region:instance_name']
 

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -397,16 +397,6 @@ cloudsqlProxy:
       value: "true"
     - name: CSQL_PROXY_STRUCTURED_LOGS
       value: "true"
-  # The lifecycle.preStop is used to delay the pod termination to allow the
-  # remaining connections from main container to exit gracefully.
-  lifecycle:
-    preStop:
-      exec:
-        command:
-          - /bin/sh
-          - -c
-          - /bin/sleep 30
-
   # The /startup probe returns OK when the proxy is ready to receive
   # connections from the application. In this example, k8s will check
   # once a second for 60 seconds.


### PR DESCRIPTION
https://demoforthedaves.atlassian.net/browse/SRE-4987
- Fix bug where v2 version can end with no `args` nor `command` in template
- Get `instanceConnectionName` from either variables or `args`or `command` and use it with proper image version
- Add `--quiet` because by default is logging "Accepted connection ..." for every connection
- Remove socket path file during preStop
- Comments on default and fail messages