### PR TITLE
PLAT-1491 abstract cloudsql-proxy in crons

### DIFF
--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8-beta.1
+version: 0.2.0-beta.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/job/templates/cronjob.yaml
+++ b/charts/job/templates/cronjob.yaml
@@ -214,13 +214,14 @@ spec:
               image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .proxyImageTag }}"
               imagePullPolicy: Always
               command: [ "/bin/sh", "-c" ]
-              args: |-
+              args:
+              - |-
                 # start the proxy in the background
-                /cloud_sql_proxy \
+                /cloud-sql-proxy \
                   --private-ip \
                   --quiet \
                   --unix-socket /cloudsql \
-                  -instances={{ required "Must specify an instanceConnectionName if using cloudsqlProxy" .instanceConnectionName }} &
+                  {{ required "Must specify an instanceConnectionName if using cloudsqlProxy" .instanceConnectionName }} &
 
                 CHILD_PID=$!
 

--- a/charts/job/templates/cronjob.yaml
+++ b/charts/job/templates/cronjob.yaml
@@ -163,7 +163,7 @@ spec:
                       fieldPath: metadata.name
               {{- if .Values.cloudsqlProxy.enabled }}
                 - name: DB_SOCKETPATH
-                  value: /cloudsql/{{ .Values.cloudsqlProxy.database }}
+                  value: /cloudsql/{{ .Values.cloudsqlProxy.instanceConnectionName }}
               {{- end }}
               {{- if .Values.apm.enabled }}
                 - name: DD_ENV
@@ -220,7 +220,7 @@ spec:
                   --private-ip \
                   --quiet \
                   --unix-socket /cloudsql \
-                  -instances={{ required "Must specify a database if using cloudsqlProxy" .database }} &
+                  -instances={{ required "Must specify an instanceConnectionName if using cloudsqlProxy" .instanceConnectionName }} &
 
                 CHILD_PID=$!
 

--- a/charts/job/templates/cronjob.yaml
+++ b/charts/job/templates/cronjob.yaml
@@ -40,7 +40,7 @@ spec:
       template:
         metadata:
           annotations:
-            {{/*
+            {{- /*
             https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
             */}}
             checksum/config: {{ .Values.env | toString | sha256sum }}
@@ -63,7 +63,7 @@ spec:
           serviceAccountName: {{ include "job.serviceAccountName" . }}
           {{- if .Values.podSecurityContext }}
           securityContext:
-            {{- toYaml .Values.podSecurityContext | nindent 12 }}         
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           {{- end }}
           {{- if (or .Values.initContainer.enabled .Values.failOnMissingLocalSecrets.enabled) }}
           initContainers:
@@ -87,6 +87,179 @@ spec:
             {{- end }}
           {{- end }}
           containers:
+            - name: {{ include "job.name" . }}
+              {{- if .Values.securityContext }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              {{- end }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- if .Values.command }}
+              {{- if .Values.entrypointScript }}
+              {{- fail "Cannot specify entrypointScript alongside command" }}
+              {{- end }}
+              command:
+                {{- toYaml .Values.command | nindent 14 }}
+              {{- end }}
+              {{- if .Values.args }}
+              {{- if .Values.entrypointScript }}
+              {{- fail "Cannot specify entrypointScript alongside args" }}
+              {{- end }}
+              args:
+                {{- toYaml .Values.args | nindent 14 }}
+              {{- end }}
+              {{- if .Values.entrypointScript }}
+              command: [ "/bin/sh", "-c" ]
+              args:
+                - |-
+                  # if the main script exits with a 0 status code,
+                  # touch a file to cause the cloudsql-proxy sidecar to terminate
+                  # otherwise, the proxy will continue running so that a container restart works
+                  set -e
+{{ .Values.entrypointScript | indent 18 }}
+                  touch /tmp/main-terminated
+              {{- end }}
+              {{- if .Values.resources }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              {{- if .Values.cloudsqlProxy.enabled }}
+                - name: cloudsql
+                  mountPath: /cloudsql
+              {{- end }}
+              {{- if .Values.sideCar.enabled }}
+                - name: {{ .Values.sideCar.volumeName }}
+                  mountPath: /{{ .Values.sideCar.volumeName }}
+              {{- end }}
+              {{- if .Values.existingSecretMount.enabled }}
+                {{- range .Values.existingSecretMount.secrets }}
+                - name: {{ .name }}-vol
+                  mountPath: {{ .mountPath }}
+                  readOnly: true
+                {{- end }}
+              {{- end }}
+              {{- if .Values.lifecycle }}
+              lifecycle:
+                {{- toYaml .Values.lifecycle | nindent 16 }}
+              {{- end }}
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: NODE_ENV
+                  value: {{ .Values.environment }}
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.name
+              {{- if .Values.cloudsqlProxy.enabled }}
+                - name: DB_SOCKETPATH
+                  value: /cloudsql/{{ .Values.cloudsqlProxy.database }}
+              {{- end }}
+              {{- if .Values.apm.enabled }}
+                - name: DD_ENV
+                  value: {{ .Values.apm.datadogEnvironment | default .Values.environment }}
+                - name: DD_TRACE_AGENT_HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                {{- /*
+                Used by hot-shots package as default StatsD host
+                */}}
+                - name: DD_AGENT_HOST
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: DD_SERVICE_NAME
+                  value: {{ include "job.name" . }}
+              {{- end }}
+              envFrom:
+                {{- if .Values.existingConfigMapName }}
+                - configMapRef:
+                    name: {{ .Values.existingConfigMapName }}
+                {{- end }}
+                {{- if .Values.env }}
+                - configMapRef:
+                    name: {{ .Values.configMapName | default (include "job.name" .) }}
+                {{- end}}
+                {{- if and (.Values.createSecret) (not .Values.createSecretName) }}
+                - secretRef:
+                    name: {{ include "job.name" . }}
+                {{- else if and (.Values.createSecret) (.Values.createSecretName) }}
+                - secretRef:
+                    name: {{ .Values.createSecretName }}
+                {{- else if and (.Values.existingSecretName) (not .Values.createSecret) }}
+                - secretRef:
+                    name: {{ .Values.existingSecretName }}
+                {{- else if and (.Values.existingSecretList) (not .Values.createSecret) (not .Values.existingSecretName) }}
+                {{- range .Values.existingSecretList }}
+                - secretRef:
+                    name: {{ . }}
+                {{- end }}
+                {{- else }}
+                {{- end }}{{/* end job container */}}
+
+            {{- if .Values.cloudsqlProxy.enabled }}
+            {{- with .Values.cloudsqlProxy }}
+            - name: cloudsql-proxy
+              image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .proxyImageTag }}"
+              imagePullPolicy: Always
+              command: [ "/bin/sh", "-c" ]
+              args: |-
+                # start the proxy in the background
+                /cloud_sql_proxy \
+                  --private-ip \
+                  --quiet \
+                  --unix-socket /cloudsql \
+                  -instances={{ required "Must specify a database if using cloudsqlProxy" .database }} &
+
+                CHILD_PID=$!
+
+                # this loop polls for a file indicating the main app has terminated successfully
+                # which writes a file to a shared volume
+                # if that file exists, the proxy is stopped so the job can complete
+                (while true;
+                  do if [[ -f "/tmp/main-terminated" ]]; then
+                    kill $CHILD_PID;
+                    echo "Killed $CHILD_PID as the main container terminated.";
+                    # breaks the outer "while true" loop
+                    break 2;
+                  fi;
+
+                sleep 1;
+                done) &
+
+                wait $CHILD_PID
+                PROXY_EXIT=$?
+
+                # detect if we're exiting due to the main job exiting, in which case we can also exit this cleanly
+                if [[ -f "/tmp/main-terminated" ]]; then
+                  echo "Job completed. Exiting..."; exit 0;
+                else
+                  # the proxy exited on its own. Use its exit code for the pod
+                  echo "Proxy exited on its own. code $PROXY_EXIT"
+                  exit $PROXY_EXIT
+                fi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                  readOnly: true
+                - name: cloudsql
+                  mountPath: /cloudsql
+              resources:
+                {{- toYaml .resources | nindent 16 }}
+            {{- end }}{{/* end with cloudSqlProxy */}}
+            {{- end }}{{/* end cloudSqlProxy.enabled */}}
+
             {{- if .Values.sideCar.enabled }}
             - name: {{ .Values.sideCar.name }}
               image: "{{ .Values.sideCar.image.repository }}"
@@ -138,105 +311,15 @@ spec:
                 {{- else }}
                 {{- end }}
               {{- end }}
-            {{- end }}
-            - name: {{ include "job.name" . }}
-              {{- if .Values.securityContext }}
-              securityContext:
-                {{- toYaml .Values.securityContext | nindent 16 }}
-              {{- end }}
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
-              {{- if .Values.command }}
-              command:
-                {{- toYaml .Values.command | nindent 14 }}
-              {{- end }}
-              {{- if .Values.args }}
-              args:
-                {{- toYaml .Values.args | nindent 14 }}
-              {{- end }}
-              {{- if .Values.resources }}
-              resources:
-                {{- toYaml .Values.resources | nindent 16 }}
-              {{- end }}                  
-              volumeMounts:
-                - name: tmp
-                  mountPath: /tmp
-              {{- if .Values.sideCar.enabled }}
-                - name: {{ .Values.sideCar.volumeName }}
-                  mountPath: /{{ .Values.sideCar.volumeName }}
-              {{- end }}
-              {{- if .Values.existingSecretMount.enabled }}
-                {{- range .Values.existingSecretMount.secrets }}
-                - name: {{ .name }}-vol
-                  mountPath: {{ .mountPath }}
-                  readOnly: true
-                {{- end }}
-              {{- end }}
-              {{- if .Values.lifecycle }}
-              lifecycle:
-                {{- toYaml .Values.lifecycle | nindent 16 }}
-              {{- end }}
-              env:
-                - name: NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: NODE_ENV
-                  value: {{ .Values.environment }}
-                - name: NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      apiVersion: v1
-                      fieldPath: metadata.name
-              {{- if .Values.apm.enabled }}
-                - name: DD_ENV
-                  value: {{ .Values.apm.datadogEnvironment | default .Values.environment }}
-                - name: DD_TRACE_AGENT_HOSTNAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.hostIP
-                {{/*
-                Used by hot-shots package as default StatsD host
-                */}}
-                - name: DD_AGENT_HOST
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.hostIP
-                - name: DD_SERVICE_NAME
-                  value: {{ include "job.name" . }}
-              {{- end }}
-              envFrom:
-                {{- if .Values.existingConfigMapName }}
-                - configMapRef:
-                    name: {{ .Values.existingConfigMapName }}
-                {{- end }}
-                {{- if .Values.env }}
-                - configMapRef:
-                    name: {{ .Values.configMapName | default (include "job.name" .) }}
-                {{- end}}
-                {{- if and (.Values.createSecret) (not .Values.createSecretName) }}
-                - secretRef:
-                    name: {{ include "job.name" . }}
-                {{- else if and (.Values.createSecret) (.Values.createSecretName) }}
-                - secretRef:
-                    name: {{ .Values.createSecretName }}
-                {{- else if and (.Values.existingSecretName) (not .Values.createSecret) }}
-                - secretRef:
-                    name: {{ .Values.existingSecretName }}
-                {{- else if and (.Values.existingSecretList) (not .Values.createSecret) (not .Values.existingSecretName) }}
-                {{- range .Values.existingSecretList }}
-                - secretRef:
-                    name: {{ . }}
-                {{- end }}
-                {{- else }}
-                {{- end }}
+            {{- end }}{{/* end sidecar.Enabled */}}
+
           volumes:
             - name: tmp
               emptyDir: {}
+          {{- if .Values.cloudsqlProxy.enabled }}
+            - name: cloudsql
+              emptyDir: {}
+          {{- end }}
           {{- if .Values.sideCar.enabled }}
             - name: {{ .Values.sideCar.volumeName }}
               emptyDir: {}

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -196,13 +196,14 @@ spec:
           image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .proxyImageTag }}"
           imagePullPolicy: Always
           command: [ "/bin/sh", "-c" ]
-          args: |-
+          args:
+          - |-
             # start the proxy in the background
-            /cloud_sql_proxy \
+            /cloud-sql-proxy \
               --private-ip \
               --quiet \
               --unix-socket /cloudsql \
-              -instances={{ required "Must specify an instanceConnectionName if using cloudsqlProxy" .instanceConnectionName }} &
+              {{ required "Must specify an instanceConnectionName if using cloudsqlProxy" .instanceConnectionName }} &
 
             CHILD_PID=$!
 

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -144,7 +144,7 @@ spec:
                   fieldPath: metadata.name
           {{- if .Values.cloudsqlProxy.enabled }}
             - name: DB_SOCKETPATH
-              value: /cloudsql/{{ .Values.cloudsqlProxy.database }}
+              value: /cloudsql/{{ .Values.cloudsqlProxy.instanceConnectionName }}
           {{- end }}
           {{- if .Values.apm.enabled }}
             - name: DD_ENV
@@ -202,7 +202,7 @@ spec:
               --private-ip \
               --quiet \
               --unix-socket /cloudsql \
-              -instances={{ required "Must specify a database if using cloudsqlProxy" .database }} &
+              -instances={{ required "Must specify an instanceConnectionName if using cloudsqlProxy" .instanceConnectionName }} &
 
             CHILD_PID=$!
 

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -44,7 +44,7 @@ spec:
       serviceAccountName: {{ include "job.serviceAccountName" . }}
       {{- if .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}         
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       {{- if (or .Values.initContainer.enabled .Values.failOnMissingLocalSecrets.enabled) }}
       initContainers:
@@ -68,6 +68,180 @@ spec:
         {{- end }}
       {{- end }}
       containers:
+        - name: {{ include "job.name" . }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          {{- if .Values.entrypointScript }}
+          {{- fail "Cannot specify entrypointScript alongside command" }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.command | nindent 10 }}
+          {{- end }}
+          {{- if .Values.args }}
+          {{- if .Values.entrypointScript }}
+          {{- fail "Cannot specify entrypointScript alongside args" }}
+          {{- end }}
+          args:
+            {{- toYaml .Values.args | nindent 10 }}
+          {{- end }}
+          {{- if .Values.entrypointScript }}
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - |-
+              # if the main script exits with a 0 status code,
+              # touch a file to cause the cloudsql-proxy sidecar to terminate
+              # otherwise, the proxy will continue running so that a container restart works
+              set -e
+{{ .Values.entrypointScript | indent 14 }}
+              touch /tmp/main-terminated
+          {{- end }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- if .Values.cloudsqlProxy.enabled }}
+            - name: cloudsql
+              mountPath: /cloudsql
+          {{- end }}
+          {{- if .Values.sideCar.enabled }}
+            - name: {{ .Values.sideCar.volumeName }}
+              mountPath: /{{ .Values.sideCar.volumeName }}
+          {{- end }}
+          {{- if .Values.existingSecretMount.enabled }}
+            {{- range .Values.existingSecretMount.secrets }}
+            - name: {{ .name }}-vol
+              mountPath: {{ .mountPath }}
+              readOnly: true
+            {{- end }}
+          {{- end }}
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_ENV
+              value: {{ .Values.environment }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          {{- if .Values.cloudsqlProxy.enabled }}
+            - name: DB_SOCKETPATH
+              value: /cloudsql/{{ .Values.cloudsqlProxy.database }}
+          {{- end }}
+          {{- if .Values.apm.enabled }}
+            - name: DD_ENV
+              value: {{ .Values.apm.datadogEnvironment | default .Values.environment }}
+            - name: DD_TRACE_AGENT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{/*
+            Used by hot-shots package as default StatsD host
+            */}}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_SERVICE_NAME
+              value: {{ include "job.name" . }}
+          {{- end }}
+          envFrom:
+            {{- if .Values.existingConfigMapName }}
+            - configMapRef:
+                name: {{ .Values.existingConfigMapName }}
+            {{- end }}
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ .Values.configMapName | default (include "job.name" .) }}
+            {{- end}}
+            {{- if and (.Values.createSecret) (not .Values.createSecretName) }}
+            - secretRef:
+                name: {{ include "job.name" . }}
+            {{- else if and (.Values.createSecret) (.Values.createSecretName) }}
+            - secretRef:
+                name: {{ .Values.createSecretName }}
+            {{- else if and (.Values.existingSecretName) (not .Values.createSecret) }}
+            - secretRef:
+                name: {{ .Values.existingSecretName }}
+            {{- else if and (.Values.existingSecretList) (not .Values.createSecret) (not .Values.existingSecretName) }}
+            {{- range .Values.existingSecretList }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- else }}
+            {{- end }}
+        {{/* end job container */}}
+
+        {{- if .Values.cloudsqlProxy.enabled }}
+        {{- with .Values.cloudsqlProxy }}
+        - name: cloudsql-proxy
+          image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:{{ .proxyImageTag }}"
+          imagePullPolicy: Always
+          command: [ "/bin/sh", "-c" ]
+          args: |-
+            # start the proxy in the background
+            /cloud_sql_proxy \
+              --private-ip \
+              --quiet \
+              --unix-socket /cloudsql \
+              -instances={{ required "Must specify a database if using cloudsqlProxy" .database }} &
+
+            CHILD_PID=$!
+
+            # this loop polls for a file indicating the main app has terminated successfully
+            # which writes a file to a shared volume
+            # if that file exists, the proxy is stopped so the job can complete
+            (while true;
+              do if [[ -f "/tmp/main-terminated" ]]; then
+                kill $CHILD_PID;
+                echo "Killed $CHILD_PID as the main container terminated.";
+                # breaks the outer "while true" loop
+                break 2;
+              fi;
+
+            sleep 1;
+            done) &
+
+            wait $CHILD_PID
+            PROXY_EXIT=$?
+
+            # detect if we're exiting due to the main job exiting, in which case we can also exit this cleanly
+            if [[ -f "/tmp/main-terminated" ]]; then
+              echo "Job completed. Exiting..."; exit 0;
+            else
+              # the proxy exited on its own. Use its exit code for the pod
+              echo "Proxy exited on its own. code $PROXY_EXIT"
+              exit $PROXY_EXIT
+            fi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+              readOnly: true
+            - name: cloudsql
+              mountPath: /cloudsql
+          resources:
+            {{- toYaml .resources | nindent 16 }}
+        {{- end }}{{/* end with cloudSqlProxy */}}
+        {{- end }}{{/* end cloudSqlProxy.enabled */}}
+
         {{- if .Values.sideCar.enabled }}
         - name: {{ .Values.sideCar.name }}
           image: "{{ .Values.sideCar.image.repository }}"
@@ -119,105 +293,14 @@ spec:
             {{- else }}
             {{- end }}
           {{- end }}
-        {{- end }}
-        - name: {{ include "job.name" . }}
-          {{- if .Values.securityContext }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.command }}
-          command:
-            {{- toYaml .Values.command | nindent 10 }}
-          {{- end }}
-          {{- if .Values.args }}
-          args:
-            {{- toYaml .Values.args | nindent 10 }}
-          {{- end }}
-          {{- if .Values.resources }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- end }}                  
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-          {{- if .Values.sideCar.enabled }}
-            - name: {{ .Values.sideCar.volumeName }}
-              mountPath: /{{ .Values.sideCar.volumeName }}
-          {{- end }}
-          {{- if .Values.existingSecretMount.enabled }}
-            {{- range .Values.existingSecretMount.secrets }}
-            - name: {{ .name }}-vol
-              mountPath: {{ .mountPath }}
-              readOnly: true
-            {{- end }}
-          {{- end }}
-          {{- if .Values.lifecycle }}
-          lifecycle:
-            {{- toYaml .Values.lifecycle | nindent 12 }}
-          {{- end }}
-          env:
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: NODE_ENV
-              value: {{ .Values.environment }}
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-          {{- if .Values.apm.enabled }}
-            - name: DD_ENV
-              value: {{ .Values.apm.datadogEnvironment | default .Values.environment }}
-            - name: DD_TRACE_AGENT_HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            {{/*
-            Used by hot-shots package as default StatsD host
-            */}}
-            - name: DD_AGENT_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: DD_SERVICE_NAME
-              value: {{ include "job.name" . }}
-          {{- end }}
-          envFrom:
-            {{- if .Values.existingConfigMapName }}
-            - configMapRef:
-                name: {{ .Values.existingConfigMapName }}
-            {{- end }}
-            {{- if .Values.env }}
-            - configMapRef:
-                name: {{ .Values.configMapName | default (include "job.name" .) }}
-            {{- end}}
-            {{- if and (.Values.createSecret) (not .Values.createSecretName) }}
-            - secretRef:
-                name: {{ include "job.name" . }}
-            {{- else if and (.Values.createSecret) (.Values.createSecretName) }}
-            - secretRef:
-                name: {{ .Values.createSecretName }}
-            {{- else if and (.Values.existingSecretName) (not .Values.createSecret) }}
-            - secretRef:
-                name: {{ .Values.existingSecretName }}
-            {{- else if and (.Values.existingSecretList) (not .Values.createSecret) (not .Values.existingSecretName) }}
-            {{- range .Values.existingSecretList }}
-            - secretRef:
-                name: {{ . }}
-            {{- end }}
-            {{- else }}
-            {{- end }}
+        {{- end }}{{/* end sidecar */}}
       volumes:
         - name: tmp
           emptyDir: {}
+      {{- if .Values.cloudsqlProxy.enabled }}
+        - name: cloudsql
+          emptyDir: {}
+      {{- end }}
       {{- if .Values.sideCar.enabled }}
         - name: {{ .Values.sideCar.volumeName }}
           emptyDir: {}

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -16,9 +16,26 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
 
+# Use Kubernetes command and args for fine-grained control
 command: []
 args: []
-port: 8080
+
+# entrypointScript will run via sh with an additional wrapper to handle graceful sidecar shutdown
+# If you're using the standard cloudsql-proxy sidecar, you should use this option over command+args
+entrypointScript: ""
+
+# if you need a cloudsql-proxy sidecar, enable this and specify your database connection string
+cloudsqlProxy:
+  enabled: false
+  # this should be your GCP database as project:location:instance, e.g. internal-1-4825:us-central1:staging-2
+  database: ""
+  proxyImageTag: 2.11.4-alpine
+  resources:
+    requests:
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+
 
 # Init container must have a name, image and command to run before
 # deployContainer initializes.  Both containers share a /tmp volume mount.
@@ -40,7 +57,7 @@ timeZone: null
 suspend: false
 failedJobsHistoryLimit: "1"
 successfulJobsHistoryLimit: "3"
-# The optional startingDeadlineSeconds field indicates the maximum number of seconds 
+# The optional startingDeadlineSeconds field indicates the maximum number of seconds
 # the CronJob can take to start if it misses its scheduled time for any reason. Missed CronJobs are considered failures.
 startingDeadlineSeconds: "600"
 # The optional spec.concurrencyPolicy field specifies how to treat concurrent executions of a Job created by the CronJob controller.

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -21,20 +21,27 @@ command: []
 args: []
 
 # entrypointScript will run via sh with an additional wrapper to handle graceful sidecar shutdown
-# If you're using the standard cloudsql-proxy sidecar, you should use this option over command+args
+# If you're using the standard cloudsql-proxy sidecar, you should use this option over command+args.
+#
+# You can use any shell syntax you want here (/bin/sh). The chart runs the shell script,
+# then triggers the cloudsql-proxy sidecar to shut down.
+#
+# For standard NodeJS crons with a bootstrap for secrets, this should be:
+# ./bootstrap-and-run.sh node dist/crons/your-cron-job.js
 entrypointScript: ""
 
 # if you need a cloudsql-proxy sidecar, enable this and specify your database connection string
 cloudsqlProxy:
   enabled: false
   # this should be your GCP database as project:location:instance, e.g. internal-1-4825:us-central1:staging-2
-  database: ""
+  instanceConnectionName: ""
   proxyImageTag: 2.11.4-alpine
   resources:
     requests:
-      cpu: "100m"
+      cpu: 50m
+      memory: 25Mi
     limits:
-      memory: "256Mi"
+      memory: 256Mi
 
 
 # Init container must have a name, image and command to run before


### PR DESCRIPTION
A note on review: I did move the main container to the top of the list.  All the new stuff is between `{{ cloudsqlProxy}}` blocks (and a few other obvious places).  the `sideCar` blocks are cut-and-paste changes.

Copying the ticket description here for what this is all about.

---

Kubernetes Jobs are a notorious pain for the cloudsql-proxy sidecar pattern we use for database access.  The problem is that a Job is only considered complete when all containers have exited, but the cloudsql-proxy container won’t naturally exit when the main pod does. 

We’ve long used a chunk of boilerplate copied from a [GitHub comment](https://github.com/kubernetes/kubernetes/issues/25908#issuecomment-365924958) that makes the cloudsql-proxy container exit when the main job container exits.  This boilerplate has a fatal flaw, however: it exits regardless of the exit code the job provides.  This means crons are not restartable: you can set up restart policies if your code OOMs or runs into a transient error, but then the cloudsql-proxy sidecar will exit normally before the restart and the pod will almost certainly die again immediately due to lack of DB connection.  The boilerplate needs to be fixed.

In the Helm world, we’ve continued to reuse this boilerplate by copy/pasting in our values files.  We want to take this opportunity to provide a more streamlined experience for cloudsql-proxy sidecars in Helm chart values, so that we’re not copying chunks of boilerplate around everywhere.

 - Abstract values for cloudsql-setup.  Allow minimal direct configuration of the container: you can set the database name and resources, and that’s about it, cloudsql-proxy sidecar.
  - This lets the chart control the boilerplate, and will allow an easy transition to proper sidecars when we're on Kubernetes 1.26.

- Automatically set up volumes and DB_SOCKETPATH env if using the sidecar so we don't have magic values cropping up in all charts

- Update to cloudsql-proxy v2 while we’re at it.
  - We don’t really need probes for jobs, since jobs are not long-running like deployments.  Any transient errors like “could not get credentials” will exit the process with an error code and restart naturally.

- Leave existing direct setup alone (via sideCar / command / args).  These can still be used for experimentation or advanced use cases.