### PR TITLE
SRE-4816 - Policy to detect nginx-public

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1-beta.1
+version: 0.1.1-beta.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kyverno-policies/templates/common-ingress.yaml
+++ b/charts/kyverno-policies/templates/common-ingress.yaml
@@ -38,7 +38,7 @@ spec:
               matchLabels:
                 kyverno-ingress-policy: skip
       validate:
-        message: "Public ingress detected. Remove Public Ingress and switch to Cloud Armor."
+        message: "Ingress nginx-public detected, switch to Cloud Armor."
         pattern:
           metadata:
             annotations:

--- a/charts/kyverno-policies/templates/common-ingress.yaml
+++ b/charts/kyverno-policies/templates/common-ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.policySets.common.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: ingress
+  namespace: {{ .Values.policySets.common.namespace }}
+  labels:
+    {{- include "kyverno-policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Require Requests and Limits
+    policies.kyverno.io/category: Security Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      This policy alerts on ingress configurations within the cluster that are not private. Public exposure
+      of applications without proper security measures poses significant risks. It is recommended
+      to use Cloud Armor instead of public nginx for enhanced protection,
+      customizable security rules, and improved control over incoming traffic.
+spec:
+  validationFailureAction: {{ .Values.policySets.common.validationFailureAction }}
+  rules:
+    - name: public-ingress
+      match:
+        any:
+        - resources:
+            kinds:
+            - Ingress
+      exclude:
+        any:
+        - resources:
+            namespaces:
+            - sys
+        - resources:
+            kinds:
+            - Ingress
+            selector:
+              matchLabels:
+                kyverno-ingress-policy: skip
+      validate:
+        message: "Public ingress detected. Remove Public Ingress and switch to Cloud Armor."
+        pattern:
+          metadata:
+            annotations:
+              =(kubernetes.io/ingress.class): "!nginx-public"
+{{- end }}

--- a/charts/kyverno-policies/templates/common-ingress.yaml
+++ b/charts/kyverno-policies/templates/common-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/subject: Ingress
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/description: >-
-      This policy alerts on ingress configurations within the cluster that are not private. Public exposure
+      This policy alerts on ingress configurations within the cluster that are public using nginx. Public exposure
       of applications without proper security measures poses significant risks. It is recommended
       to use Cloud Armor instead of public nginx for enhanced protection,
       customizable security rules, and improved control over incoming traffic.


### PR DESCRIPTION
[SRE-4816](https://demoforthedaves.atlassian.net/browse/SRE-4816)

- Policy alerts on any nginx-public either with or without CloudArmor (nginx-public should be disabled or removed from code)
- Applies to all environments

[SRE-4816]: https://demoforthedaves.atlassian.net/browse/SRE-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ