### PR TITLE
[SRE-4961] Migrate `release.yml` to the new gha runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-small-spot
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
**Ticket**
[SRE-4961](https://demoforthedaves.atlassian.net/browse/SRE-4961)

**Ticket and brief summary**
- Use `self-hosted-small-spot` instead of the legacy runners

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[SRE-4961]: https://demoforthedaves.atlassian.net/browse/SRE-4961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ