### PR TITLE
Sre 5012/cloudsql proxy

### DIFF
--- a/charts/cloudsql-proxy/Chart.yaml
+++ b/charts/cloudsql-proxy/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: cloudsql-proxy
+description: Standard Service Template
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0-beta.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.17.0

--- a/charts/cloudsql-proxy/Chart.yaml
+++ b/charts/cloudsql-proxy/Chart.yaml
@@ -20,4 +20,10 @@ version: 0.1.0-beta.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.0
+appVersion: 1.1.0
+
+# section to help categorize and search for this chart in repositories.
+keywords:
+  - cloudsql
+  - proxy
+  - database

--- a/charts/cloudsql-proxy/README.md
+++ b/charts/cloudsql-proxy/README.md
@@ -1,0 +1,36 @@
+# CloudSQL Proxy v2 Helm Chart
+
+## Description
+
+This Helm chart deploys a CloudSQL Proxy v2 instance in Kubernetes, facilitating connections to Google Cloud SQL databases. It's designed to provide an alternative to the sidecar pattern, allowing internal Kubernetes service name-based connections when TCP connections are required.
+
+## Purpose
+
+The main purpose of this chart is to:
+
+1. Deploy Cloud SQL Proxy v2 as a standalone service in Kubernetes.
+2. Enable TCP connections to Cloud SQL databases using internal Kubernetes service names.
+3. Provide a flexible and scalable solution for applications requiring database access without using the sidecar pattern with socket paths.
+
+## Features
+
+- Kyverno compliant, meeting policy requirements for resource requests and probes (includes startup, liveness, and readiness probes)
+- Supports multiple replica deployments
+- Configurable security contexts and resource limits
+- Built-in liveness, readiness, and startup probes
+- Support for custom annotations and labels
+- Flexible volume mounting for secrets and configmaps
+- Integration with Datadog for monitoring and APM (optional)
+- Topology spread constraints for high availability deployments
+
+## Prerequisites
+
+- Kubernetes
+- Helm 
+- Google Cloud Platform account with Cloud SQL instance(s)
+
+## Notes
+
+- Ensure that the necessary GCP credentials are properly configured and accessible to the pods.
+- This chart is designed for Cloud SQL Proxy v2. Make sure you're using a compatible version of the proxy image.
+- For production use, always review and adjust the security settings as per your organization's requirements.

--- a/charts/cloudsql-proxy/templates/_helpers.tpl
+++ b/charts/cloudsql-proxy/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.name" -}}
+{{- default .Release.Name ( required ".Values.name is missing, this can be caused by a mismatch in chart alias reference" .Values.name ) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "common.labels" -}}
+helm.sh/chart: {{ include "common.chart" . }}
+{{ include "common.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+  {{- println "" }}
+  {{- toYaml .Values.additionalLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "common.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "common.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "common.serviceAccountName" -}}
+{{- if and (.Values.serviceAccount.create) (not .Values.serviceAccount.existingNameSA) }}
+{{- default (include "common.name" .) .Values.serviceAccount.name }}
+{{- else if and (not .Values.serviceAccount.create) (.Values.serviceAccount.existingNameSA) }}
+{{- default (include "common.name" .) .Values.serviceAccount.existingNameSA }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name for the custom config configmap.
+*/}}
+{{- define "common.customConfig.name" -}}
+{{ .Values.customConfig.name | default (print (include "common.name" .) "-customconfig") }}
+{{- end -}}
+
+{{/*
+Validate required values
+*/}}
+{{- define "common.validateValues" -}}
+{{- if not .Values.deploymentContainer.instanceConnectionName -}}
+{{- fail "deploymentContainer.instanceConnectionName is required but not set" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cloudsql-proxy/templates/configmap.yaml
+++ b/charts/cloudsql-proxy/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMapName | default (include "common.name" .) }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  {{- .Values.env | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/cloudsql-proxy/templates/deployment.yaml
+++ b/charts/cloudsql-proxy/templates/deployment.yaml
@@ -1,0 +1,194 @@
+{{- include "common.validateValues" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "common.name" . }}
+  labels:
+    tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+    run: {{ include "common.name" . }}
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "common.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- /*
+        https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        */}}
+        checksum/config: {{ .Values.env | toString | sha256sum }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+      labels:
+        tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+        run: {{ include "common.name" . }}
+        {{- include "common.selectorLabels" . | nindent 8 }}
+      {{- if .Values.additionalLabels }}
+        {{- .Values.additionalLabels | toYaml | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "common.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or (.Values.topologySpreadConstraints.zone.enabled) (.Values.topologySpreadConstraints.node.enabled) }}
+      topologySpreadConstraints:
+        {{- if .Values.topologySpreadConstraints.zone.enabled }}
+        - topologyKey: {{ .Values.topologySpreadConstraints.zone.topologyKey }}
+          maxSkew: {{ .Values.topologySpreadConstraints.zone.maxSkew }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.zone.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "common.selectorLabels" . | nindent 14 }}
+        {{- end }}
+        {{- if .Values.topologySpreadConstraints.node.enabled }}
+        - topologyKey: {{ .Values.topologySpreadConstraints.node.topologyKey }}
+          maxSkew: {{ .Values.topologySpreadConstraints.node.maxSkew }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.node.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "common.selectorLabels" . | nindent 14 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ include "common.name" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ .Values.image.repository }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.deploymentContainer.ports.http.number }}
+              protocol: {{ .Values.deploymentContainer.ports.http.protocol }}
+            - name: mysql
+              containerPort: {{ .Values.deploymentContainer.ports.mysql.number }}
+              protocol: {{ .Values.deploymentContainer.ports.mysql.protocol }}
+          livenessProbe:
+            {{- toYaml .Values.deploymentContainer.LivenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.deploymentContainer.ReadinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.deploymentContainer.StartupProbe | nindent 12 }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.deploymentContainer.instanceConnectionName }}
+          args:
+            - "--private-ip"
+            - "--quiet"
+            - "--address=0.0.0.0"
+            - "--port={{ .Values.deploymentContainer.ports.mysql.number }}"
+            - {{ .Values.deploymentContainer.instanceConnectionName }}
+          {{- end }}
+          env:
+            {{/*
+            Environment variables used by the common logger
+            https://github.com/dave-inc/logger/blob/6c69fe2cba9bb954494fe9c6b5297633c1a19aeb/README.md#L69
+            */}}
+            - name: DEPLOYMENT_NAME
+              value: {{ include "common.name" . }}
+            - name: DD_VERSION
+              value: "{{ .Values.image.tag }}"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_ENV
+              value: {{ .Values.environment }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            # Enable HTTP healthchecks on port 9801. This enables /liveness,
+            # /readiness and /startup health check endpoints. Allow connections
+            # listen for connections on any interface (0.0.0.0) so that the
+            # k8s management components can reach these endpoints.
+            - name: CSQL_PROXY_HEALTH_CHECK
+              value: "true"
+            - name: CSQL_PROXY_HTTP_PORT
+              value: "9801"
+            - name: CSQL_PROXY_HTTP_ADDRESS
+              value: 0.0.0.0
+            - name: CSQL_PROXY_ADMIN_PORT
+              value: "9092"
+            # Enable the admin api server (which only listens for local connections)
+            # and enable the /quitquitquit endpoint. This allows other pods
+            # to shut down the proxy gracefully when they are ready to exit.
+            - name: CSQL_PROXY_QUITQUITQUIT
+              value: "true"
+            - name: CSQL_PROXY_STRUCTURED_LOGS
+              value: "true"
+          {{- if .Values.apm.enabled }}
+            - name: DD_ENV
+              value: {{ .Values.apm.datadogEnvironment | default .Values.environment }}
+            - name: DD_TRACE_AGENT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- if .Values.apm.otlp }}
+            - name: OTEL_TRACES_EXPORTER
+              value: "otlp"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://$(DD_TRACE_AGENT_HOSTNAME):4318"
+            {{- end }}
+            {{/*
+            Used by hot-shots package as default StatsD host
+            */}}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- if not .Values.apm.datadogSkipServiceName }}
+            - name: DD_SERVICE_NAME
+              value: {{ .Values.apm.datadogServiceName | default (include "common.name" .) }}
+            {{- end }}
+          {{- end }}
+          envFrom:
+            {{- if .Values.existingConfigMapName }}
+            - configMapRef:
+                name: {{ .Values.existingConfigMapName }}
+            {{- end }}
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ .Values.configMapName | default (include "common.name" .) }}
+            {{- end}}
+            {{- if and (.Values.createSecret) (not .Values.createSecretName) }}
+            - secretRef:
+                name: {{ include "common.name" . }}
+            {{- else if and (.Values.createSecret) (.Values.createSecretName) }}
+            - secretRef:
+                name: {{ .Values.createSecretName }}
+            {{- else if and (.Values.existingSecretName) (not .Values.createSecret) }}
+            - secretRef:
+                name: {{ .Values.existingSecretName }}
+            {{- else }}
+            {{- end }}
+          lifecycle:
+            {{- toYaml .Values.deploymentContainer.lifecycle | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cloudsql-proxy/templates/pdb.yaml
+++ b/charts/cloudsql-proxy/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.name" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
+  minAvailable: "15%"
+{{- end}}
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "common.labels" . | nindent 6 }}
+{{- end }}

--- a/charts/cloudsql-proxy/templates/service.yaml
+++ b/charts/cloudsql-proxy/templates/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name | default (include "common.name" .) }}
+  annotations:
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.deploymentContainer.ports.mysql.number }}
+      targetPort: {{ .Values.deploymentContainer.ports.mysql.number }}
+      protocol: {{ .Values.deploymentContainer.ports.mysql.protocol }}
+      name: mysql
+  selector:
+  {{- if not .Values.podSelectorLabelsOverride }}
+    {{- include "common.selectorLabels" . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.podSelectorLabelsOverride }}
+    {{- .Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cloudsql-proxy/templates/serviceaccount.yaml
+++ b/charts/cloudsql-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "common.serviceAccountName" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.workloadIdentitySA | default (include "common.serviceAccountName" .) }}@{{ required ".Values.project missing, valid GCP ProjectId is required" .Values.project }}.iam.gserviceaccount.com
+    {{ with .Values.serviceAccount.annotations }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cloudsql-proxy/values.yaml
+++ b/charts/cloudsql-proxy/values.yaml
@@ -1,0 +1,233 @@
+# Default values for cloudsql-proxy chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+# Used for NODE_ENV and DD_ENV
+environment: staging
+# Required: GCP Project where this Release will be deployed
+project: ""
+
+deploymentContainer:
+  # instanceConnectionName is the connection name of the Cloud SQL instance
+  # instanceConnectionName: project_name:region:instance_name
+
+  ports:
+    http:
+      number: 9801
+      protocol: TCP
+    # The port number for the MySQL database and the protocol to use, these values are also used to expose the values.service
+    mysql:
+      number: 3306
+      protocol: TCP
+
+  # The /liveness probe returns OK as soon as the proxy application has
+  # begun its startup process and continues to return OK until the
+  # process stops.
+  # We recommend adding a liveness probe to the proxy sidecar container.
+  livenessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /liveness
+      port: 9801
+      scheme: HTTP
+    # The probe will be checked every 10 seconds.
+    periodSeconds: 10
+    # Number of times the probe is allowed to fail before the transition
+    # from healthy to failure state.
+    # If periodSeconds = 60, 5 tries will result in five minutes of
+    # checks. The proxy starts to refresh a certificate five minutes
+    # before its expiration. If those five minutes lapse without a
+    # successful refresh, the liveness probe will fail and the pod will be
+    # restarted.
+    successThreshold: 1
+    # The probe will fail if it does not respond in 10 seconds
+    timeoutSeconds: 10
+
+  # The /readiness probe returns OK when the proxy can establish
+  # a new connections to its databases.
+  # Please use the readiness probe to the proxy sidecar with caution.
+  # An improperly configured readiness probe can cause unnecessary
+  # interruption to the application. See README.md for more detail.
+  readinessProbe:
+    httpGet:
+      path: /readiness
+      port: 9801
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 10
+    # Number of times the probe must report success to transition from failure to healthy state.
+    # Defaults to 1 for readiness probe.
+    successThreshold: 1
+    failureThreshold: 6
+
+  # The /startup probe returns OK when the proxy is ready to receive
+  # connections from the application. In this example, k8s will check
+  # once a second for 60 seconds.
+  # We strongly recommend adding a startup probe to the proxy sidecar
+  # container. This will ensure that service traffic will be routed to
+  # the pod only after the proxy has successfully started.
+  startupProbe:
+    failureThreshold: 60
+    httpGet:
+      path: /startup
+      port: 9801
+      scheme: HTTP
+    periodSeconds: 1
+    successThreshold: 1
+    timeoutSeconds: 10
+
+  ## If you want to add a preStop hooks, or any other lifecycles to your
+  ## deployment, you can define them here:
+  lifecycle:
+    preStop:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - /bin/sleep 30
+
+# terminationGracePeriodSeconds is the time to wait before forcefully terminating a pod
+# after a SIGTERM signal is sent to the container. If the preStop hook is used, this
+# value should be set to a higher value than the preStop hook timeout.
+# Setting default 1 second higher than the preStop most Dave's apps have 30 seconds
+terminationGracePeriodSeconds: 31
+
+image:
+  # This chart is only compatible with the Cloud SQL Proxy v2
+  repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4-alpine
+  pullPolicy: Always
+
+imagePullSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using Release.Name
+  name: ""
+  # IAM workload idenitity binding name
+  # If not set and serviceAccount.create:true, a name is generated using Release.Name
+  # If Release.Name is bigger than 30 characteres use this variable to overwrite it with something shorter to identify this workload
+  workloadIdentitySA: ""
+  # Specifies whether an existing service account will be used
+  # Make sure you set serviceAccount.create:false when using this option
+  # Dynamic environments will use of this one
+  existingNameSA: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  
+securityContext:
+  allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  # The name of the service is optional, If not set, a name is generated using Release.Name
+  # A good practice is the use the database name as the service name for example: staging-1 or banking-1
+  # name: ""
+  enabled: true
+  type: ClusterIP
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 25Mi
+  limits:
+    memory: 256Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+
+strategy: 
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+  type: RollingUpdate
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Used for DD_TRACE_AGENT_HOSTNAME on DD APM/Node.js potentially can be used with logger vars too
+apm:
+  enabled: false
+  otlp: false
+  # If datadogEnvironment is not defined we use variable environment as default
+  datadogEnvironment: ""
+  # Optional override DD_SERVICE_NAME to a custon name instead of common.name
+  datadogServiceName: ""
+  # Optional bool used to avoid definition of env DD_SERVICE_NAME
+  # Used to support imported workloads from legacy projects
+  # DD_SERVICE_NAME will take the value from the app name in package.json.
+  # datadogSkipServiceName: false
+  # The following variables are used in APM Code snippets in stack traces and Error Tracking: Suspect Commit
+  # They might get replace at deployment time by the CI/CD pipelines
+  commitSha: ""
+  repositoryUrl: ""
+
+# Default Logger and DD variables are defined here: https://github.com/dave-inc/charts/blob/master/common/templates/deployment.yaml
+# Custom env variables are defined here and will be populated via Deployment's ConfigMap
+env: {}
+
+# ConfigMap
+# The configMapName is optional, If not set, a name is generated using Release.Name
+configMapName: ""
+existingConfigMapName: ""
+
+# Secret
+createSecret: false
+createSecretName: ""
+# Mutually exclusive with the two above
+# existingSecretName will used as secretRef
+existingSecretName: ""
+
+# PodDisruptionBudget
+#
+# minAvailable and maxUnavailable are mutually exclusive, only one should be set.
+#
+# If podDisruptionBudget is enabled but no minAvailable or maxUnavailable fields
+# are set, the PodDisruptionTemplate template will default to `minAvailable: 15%`.
+#
+# The value for minAvailable and maxUnavailable should either be set to an integer
+# or a percentage.  For more information see the official documentation:
+#
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: "15%"
+  # maxUnavailable: 5
+
+#  This is used to apply additional labels on deployment, pods and services
+#  to properly tag the team and environment
+additionalLabels: {}
+
+# This section enables by default the topologySpreadConstraits to spread same deployment pods to multiple nodes
+# and multiple AZ when possible, rules are soft enforced by default.
+# The next are the only values that can be edited, labelSelector are set by the template.
+
+topologySpreadConstraints:
+  zone:
+    enabled: true
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+  node:
+    enabled: true
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION
This Helm chart deploys a CloudSQL Proxy v2 instance in Kubernetes, facilitating connections to Google Cloud SQL databases. It's designed to provide an alternative to the sidecar pattern, allowing internal Kubernetes service name-based connections when TCP connections are required.

https://demoforthedaves.atlassian.net/browse/SRE-5012