### PR TITLE
SRE-5261: Creating release version 0.2.0 for job Chart

### DIFF
--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0-beta.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This will make available the prod release of job-0.2.0-beta.0 to streamline cloudsql-proxy sidecar containers in the CronJob