### PR TITLE
[BEI-808] Add concept of canary to common chart

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.10
+version: 0.9.0-beta.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -136,6 +136,9 @@ Once all apps are using cloud sql proxy v2 this can be simplified.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Creates ingressStyles based on the canary deployment and migration settings.
+*/}}
 {{- define "ingressStyles" -}}
   {{- $ingressStyle := list "legacy" }}
   {{- if and .Values.canary.enabled (.Values.canary.migration) }}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -135,3 +135,13 @@ Once all apps are using cloud sql proxy v2 this can be simplified.
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "ingressStyles" -}}
+  {{- $ingressStyle := list "legacy" }}
+  {{- if and .Values.canary.enabled (.Values.canary.migration) }}
+    {{- $ingressStyle = append $ingressStyle "csm" }}
+  {{- else if and .Values.canary.enabled (not .Values.canary.migration) }}
+    {{- $ingressStyle = list "csm" }}
+  {{- end }}
+  {{- toJson $ingressStyle }}
+{{- end -}}

--- a/charts/common/templates/backendconfig.yaml
+++ b/charts/common/templates/backendconfig.yaml
@@ -3,7 +3,7 @@ apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   {{- if $.Values.canary.enabled }}
-  namespace: sys
+  namespace: {{ .Values.canary.gatewayNamespace }}
   {{- end }}
   name: {{ include "common.name" . }}
 spec:

--- a/charts/common/templates/backendconfig.yaml
+++ b/charts/common/templates/backendconfig.yaml
@@ -2,6 +2,7 @@
 {{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
 {{- range $ingressStyles }}
 {{- $ingressStyle := . }}
+---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/charts/common/templates/backendconfig.yaml
+++ b/charts/common/templates/backendconfig.yaml
@@ -1,11 +1,15 @@
 {{- if .Values.cloudArmor.enabled -}}
+{{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
+{{- range $ingressStyles }}
+{{- $ingressStyle := . }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  {{- if $.Values.canary.enabled }}
-  namespace: {{ .Values.canary.gatewayNamespace }}
+  {{- if eq $ingressStyle "csm" }}
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
-  name: {{ include "common.name" . }}
+  name: {{ include "common.name" $ }}
 spec:
-  {{- toYaml .Values.cloudArmor.backendConfig | nindent 2 }}
+  {{- toYaml $.Values.cloudArmor.backendConfig | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/common/templates/backendconfig.yaml
+++ b/charts/common/templates/backendconfig.yaml
@@ -2,6 +2,9 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
+  {{- if $.Values.canary.enabled }}
+  namespace: sys
+  {{- end }}
   name: {{ include "common.name" . }}
 spec:
   {{- toYaml .Values.cloudArmor.backendConfig | nindent 2 }}

--- a/charts/common/templates/certificate-cloudarmor.yaml
+++ b/charts/common/templates/certificate-cloudarmor.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   {{- if $.Values.canary.enabled }}
-  namespace: sys
+  namespace: {{ .Values.canary.gatewayNamespace }}
   {{- end }}
   name: {{ include "common.name" . }}
 spec:

--- a/charts/common/templates/certificate-cloudarmor.yaml
+++ b/charts/common/templates/certificate-cloudarmor.yaml
@@ -2,6 +2,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  {{- if $.Values.canary.enabled }}
+  namespace: sys
+  {{- end }}
   name: {{ include "common.name" . }}
 spec:
   secretName: {{ .Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" .) }}

--- a/charts/common/templates/certificate-cloudarmor.yaml
+++ b/charts/common/templates/certificate-cloudarmor.yaml
@@ -1,20 +1,25 @@
 {{- if .Values.cloudArmor.enabled -}}
+{{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
+{{- range $ingressStyles }}
+{{- $ingressStyle := . }}
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  {{- if $.Values.canary.enabled }}
-  namespace: {{ .Values.canary.gatewayNamespace }}
+  {{- if eq $ingressStyle "csm" }}
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
-  name: {{ include "common.name" . }}
+  name: {{ include "common.name" $ }}
 spec:
-  secretName: {{ .Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" .) }}
+  secretName: {{ $.Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" $) }}
   issuerRef:
     kind: ClusterIssuer
-    name: {{ .Values.cloudArmor.certificate.issuer }}
-  commonName: {{ .Values.cloudArmor.certificate.host | quote }}
+    name: {{ $.Values.cloudArmor.certificate.issuer }}
+  commonName: {{ $.Values.cloudArmor.certificate.host | quote }}
   dnsNames:
-    - {{ .Values.cloudArmor.certificate.host | quote }}
-{{- if .Values.cloudArmor.certificate.alternativeDnsNames }}
-    {{- toYaml .Values.cloudArmor.certificate.alternativeDnsNames | nindent 4 }}
+    - {{ $.Values.cloudArmor.certificate.host | quote }}
+{{- if $.Values.cloudArmor.certificate.alternativeDnsNames }}
+    {{- toYaml $.Values.cloudArmor.certificate.alternativeDnsNames | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/deployment-canary.yaml
+++ b/charts/common/templates/deployment-canary.yaml
@@ -15,7 +15,6 @@ kind: Deployment
 metadata:
   name: {{ include "common.name" . }}-canary
   labels:
-    canary: "true"
     tags.datadoghq.com/version: "{{ .Values.canary.image.tag }}"
     run: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
@@ -45,6 +44,7 @@ spec:
         {{- end }}
       labels:
         tags.datadoghq.com/version: "{{ .Values.canary.image.tag }}"
+        canary: "true"
       {{- if not .Values.podSelectorLabelsOverride }}
         run: {{ include "common.name" . }}
         {{- include "common.selectorLabels" . | nindent 8 }}

--- a/charts/common/templates/deployment-canary.yaml
+++ b/charts/common/templates/deployment-canary.yaml
@@ -8,9 +8,9 @@
 .Values.customConfig.enabled
 .Values.customVolumes.enabled
 ) -}}
-{{- $imageTag := printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.canary.image.tag) }}
+{{- $imageTag := default .Chart.AppVersion .Values.canary.image.tag }}
 {{- if .Values.canary.migration }}
-{{- $imageTag := printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) }}
+{{- $imageTag := default .Chart.AppVersion .Values.image.tag }}
 {{- end }}
 {{- $sqlProxyVersion := include "common.cloudsqlProxyVersion" . -}}
 {{- $sqlinstanceConnectionName := include "common.instanceConnectionName" . -}}
@@ -101,7 +101,7 @@ spec:
         {{- if .Values.failOnMissingLocalSecrets.enabled }}
         - name: check-local-secrets
           {{/* Reusing the main container's image is done on purpose */}}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ $imageTag }}"
           command: {{ toYaml .Values.failOnMissingLocalSecrets.secretsFetch.command | nindent 12}}
           args: {{ toYaml .Values.failOnMissingLocalSecrets.secretsFetch.args | nindent 12}}
           env:
@@ -113,7 +113,7 @@ spec:
         - name: {{ include "common.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ $imageTag }}"
+          image: "{{ .Values.image.repository }}:{{ $imageTag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/common/templates/deployment-canary.yaml
+++ b/charts/common/templates/deployment-canary.yaml
@@ -8,14 +8,19 @@
 .Values.customConfig.enabled
 .Values.customVolumes.enabled
 ) -}}
+{{- $imageTag := printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.canary.image.tag) }}
+{{- if .Values.canary.migration }}
+{{- $imageTag := printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) }}
+{{- end }}
 {{- $sqlProxyVersion := include "common.cloudsqlProxyVersion" . -}}
 {{- $sqlinstanceConnectionName := include "common.instanceConnectionName" . -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "common.name" . }}-canary
   labels:
-    tags.datadoghq.com/version: "{{ .Values.canary.image.tag }}"
+    tags.datadoghq.com/version: "{{ $imageTag }}"
     run: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
 spec:
@@ -43,7 +48,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        tags.datadoghq.com/version: "{{ .Values.canary.image.tag }}"
+        tags.datadoghq.com/version: "{{ $imageTag }}"
         canary: "true"
       {{- if not .Values.podSelectorLabelsOverride }}
         run: {{ include "common.name" . }}
@@ -108,7 +113,7 @@ spec:
         - name: {{ include "common.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.canary.image.tag | default .Chart.AppVersion }}"
+          image: "{{ $imageTag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -188,7 +193,7 @@ spec:
             - name: DEPLOYMENT_NAME
               value: {{ include "common.name" . }}
             - name: DD_VERSION
-              value: "{{ .Values.canary.image.tag }}"
+              value: "{{ $imageTag }}"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/common/templates/deployment-canary.yaml
+++ b/charts/common/templates/deployment-canary.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.canary.enabled -}}
 {{/* Any resource that defines a volume should be included in the list below */}}
 {{- $hasVolumes := (or
 .Values.initContainer.enabled
@@ -12,10 +13,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "common.name" . }}
+  name: {{ include "common.name" . }}-canary
   labels:
-    canary: "false"
-    tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+    canary: "true"
+    tags.datadoghq.com/version: "{{ .Values.canary.image.tag }}"
     run: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
 spec:
@@ -43,7 +44,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+        tags.datadoghq.com/version: "{{ .Values.canary.image.tag }}"
       {{- if not .Values.podSelectorLabelsOverride }}
         run: {{ include "common.name" . }}
         {{- include "common.selectorLabels" . | nindent 8 }}
@@ -107,7 +108,7 @@ spec:
         - name: {{ include "common.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.canary.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -187,7 +188,7 @@ spec:
             - name: DEPLOYMENT_NAME
               value: {{ include "common.name" . }}
             - name: DD_VERSION
-              value: "{{ .Values.image.tag }}"
+              value: "{{ .Values.canary.image.tag }}"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -406,3 +407,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -14,7 +14,6 @@ kind: Deployment
 metadata:
   name: {{ include "common.name" . }}
   labels:
-    canary: "false"
     tags.datadoghq.com/version: "{{ .Values.image.tag }}"
     run: {{ include "common.name" . }}
     {{- include "common.labels" . | nindent 4 }}
@@ -44,6 +43,7 @@ spec:
         {{- end }}
       labels:
         tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+        canary: "false"
       {{- if not .Values.podSelectorLabelsOverride }}
         run: {{ include "common.name" . }}
         {{- include "common.selectorLabels" . | nindent 8 }}

--- a/charts/common/templates/destinationrule.yaml
+++ b/charts/common/templates/destinationrule.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.canary.enabled -}}
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: {{ include "common.name" . }}
+spec:
+  host: {{ .Values.service.name | default (include "common.name" .) }}
+  subsets:
+  - labels:
+      canary: "true"
+    name: canary
+  - labels:
+      canary: "false"
+    name: production
+{{- end }}

--- a/charts/common/templates/frontendconfig.yaml
+++ b/charts/common/templates/frontendconfig.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
   {{- if $.Values.canary.enabled }}
-  namespace: {{ .Values.canary.gatewatNamespace }}
+  namespace: {{ .Values.canary.gatewayNamespace }}
   {{- end }}
   name: {{ include "common.name" . }}
 spec:

--- a/charts/common/templates/frontendconfig.yaml
+++ b/charts/common/templates/frontendconfig.yaml
@@ -2,6 +2,9 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
+  {{- if $.Values.canary.enabled }}
+  namespace: sys
+  {{- end }}
   name: {{ include "common.name" . }}
 spec:
   {{- toYaml .Values.cloudArmor.frontendConfig | nindent 2 }}

--- a/charts/common/templates/frontendconfig.yaml
+++ b/charts/common/templates/frontendconfig.yaml
@@ -1,11 +1,15 @@
 {{- if and .Values.cloudArmor.enabled .Values.cloudArmor.frontendConfig -}}
+{{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
+{{- range $ingressStyles }}
+{{- $ingressStyle := . }}
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  {{- if $.Values.canary.enabled }}
-  namespace: {{ .Values.canary.gatewayNamespace }}
+  {{- if eq $ingressStyle "csm" }}
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
-  name: {{ include "common.name" . }}
+  name: {{ include "common.name" $ }}
 spec:
-  {{- toYaml .Values.cloudArmor.frontendConfig | nindent 2 }}
+  {{- toYaml $.Values.cloudArmor.frontendConfig | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/common/templates/frontendconfig.yaml
+++ b/charts/common/templates/frontendconfig.yaml
@@ -2,6 +2,7 @@
 {{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
 {{- range $ingressStyles }}
 {{- $ingressStyle := . }}
+---
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:

--- a/charts/common/templates/frontendconfig.yaml
+++ b/charts/common/templates/frontendconfig.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
   {{- if $.Values.canary.enabled }}
-  namespace: sys
+  namespace: {{ .Values.canary.gatewatNamespace }}
   {{- end }}
   name: {{ include "common.name" . }}
 spec:

--- a/charts/common/templates/gateway-cloudarmor.yaml
+++ b/charts/common/templates/gateway-cloudarmor.yaml
@@ -26,7 +26,6 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - {{ .Values.service.name | default (include "common.name" .) }}
     {{- range .Values.cloudArmor.hosts }}
     - {{ .host | quote }}
     {{- end }}

--- a/charts/common/templates/gateway-cloudarmor.yaml
+++ b/charts/common/templates/gateway-cloudarmor.yaml
@@ -1,15 +1,14 @@
 {{- if and .Values.cloudArmor.enabled .Values.canary.enabled -}}
 {{- $labels := include "common.labels" . -}}
-{{- $svcport := .Values.service.port -}}
-{{- range .Values.ingress.hosts }}
-{{- $hostwithdashes := printf "%s" .host | replace "." "-" -}}
-{{- $hostwithdashestls := printf "%s-tls" .host | replace "." "-" }}
+{{/* {{- $svcport := .Values.service.port -}} */}}
+{{/* {{- $hostwithdashes := printf "%s" .host | replace "." "-" -}} */}}
+{{/* {{- $hostwithdashestls := printf "%s-tls" .host | replace "." "-" }} */}}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   namespace: {{ $.Values.canary.gatewayNamespace }}
-  name: {{ .name | default $hostwithdashes }}-ca
+  name: {{ include "common.name" . }}-ca
   labels:
     {{- $labels | nindent 4 }}
   {{- if .annotations }}
@@ -27,17 +26,25 @@ spec:
       name: http
       protocol: HTTP
     hosts:
+    {{- range .Values.cloudArmor.hosts }}
     - {{ .host | quote }}
-    {{- if .tls }}
-  - port:
-      number: 443
-      name: https
-      protocol: HTTPS
-    hosts:
-    - {{ .host | quote }}
-    tls:
-      mode: SIMPLE
-      credentialName: {{ .tls.secretName | default $hostwithdashestls }}
     {{- end }}
-{{- end }}
+    - {{ .Values.cloudArmor.certificate.host | quote }}
+    {{- range  .Values.cloudArmor.certificate.alternativeDnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{/* Keeping this commented out for now if we want to enable tls in the future this code requires more testing to play with CloudArmor/Gateway API */}}
+  {{/* {{- if .tls }} */}}
+  {{/* - port: */}}
+  {{/*     number: 443 */}}
+  {{/*     name: https */}}
+  {{/*     protocol: HTTPS */}}
+  {{/*   hosts: */}}
+  {{/*   {{- range .Values.cloudArmor.hosts }} */}}
+  {{/*   - {{ .host | quote }} */}}
+  {{/*   {{- end }} */}}
+  {{/*   tls: */}}
+  {{/*     mode: SIMPLE */}}
+  {{/*     credentialName: {{ .tls.secretName | default $hostwithdashestls }} */}}
+  {{/*   {{- end }} */}}
 {{- end }}

--- a/charts/common/templates/gateway-cloudarmor.yaml
+++ b/charts/common/templates/gateway-cloudarmor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cloudArmor.enabled .Values.canary -}}
+{{- if and .Values.cloudArmor.enabled .Values.canary.enabled -}}
 {{- $labels := include "common.labels" . -}}
 {{- $svcport := .Values.service.port -}}
 {{- range .Values.ingress.hosts }}
@@ -8,7 +8,7 @@
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
-  namespace: sys
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   name: {{ .name | default $hostwithdashes }}-ca
   labels:
     {{- $labels | nindent 4 }}

--- a/charts/common/templates/gateway-cloudarmor.yaml
+++ b/charts/common/templates/gateway-cloudarmor.yaml
@@ -26,6 +26,7 @@ spec:
       name: http
       protocol: HTTP
     hosts:
+    - {{ .Values.service.name | default (include "common.name" .) }}
     {{- range .Values.cloudArmor.hosts }}
     - {{ .host | quote }}
     {{- end }}

--- a/charts/common/templates/gateway-cloudarmor.yaml
+++ b/charts/common/templates/gateway-cloudarmor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.cloudArmor.enabled .Values.canary -}}
+{{- $labels := include "common.labels" . -}}
+{{- $svcport := .Values.service.port -}}
+{{- range .Values.ingress.hosts }}
+{{- $hostwithdashes := printf "%s" .host | replace "." "-" -}}
+{{- $hostwithdashestls := printf "%s-tls" .host | replace "." "-" }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  namespace: sys
+  name: {{ .name | default $hostwithdashes }}-ca
+  labels:
+    {{- $labels | nindent 4 }}
+  {{- if .annotations }}
+  annotations:
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    istio: gateway-public
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - {{ .host | quote }}
+    {{- if .tls }}
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    - {{ .host | quote }}
+    tls:
+      mode: SIMPLE
+      credentialName: {{ .tls.secretName | default $hostwithdashestls }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/gateway-cloudarmor.yaml
+++ b/charts/common/templates/gateway-cloudarmor.yaml
@@ -35,17 +35,17 @@ spec:
     - {{ . | quote }}
     {{- end }}
   {{/* Keeping this commented out for now if we want to enable tls in the future this code requires more testing to play with CloudArmor/Gateway API */}}
-  {{/* {{- if .tls }} */}}
-  {{/* - port: */}}
-  {{/*     number: 443 */}}
-  {{/*     name: https */}}
-  {{/*     protocol: HTTPS */}}
-  {{/*   hosts: */}}
-  {{/*   {{- range .Values.cloudArmor.hosts }} */}}
-  {{/*   - {{ .host | quote }} */}}
-  {{/*   {{- end }} */}}
-  {{/*   tls: */}}
-  {{/*     mode: SIMPLE */}}
-  {{/*     credentialName: {{ .tls.secretName | default $hostwithdashestls }} */}}
-  {{/*   {{- end }} */}}
+  {{/* {{- if .tls }}
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    {{- range .Values.cloudArmor.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+    tls:
+      mode: SIMPLE
+      credentialName: {{ .tls.secretName | default $hostwithdashestls }}
+     {{- end }} */}}
 {{- end }}

--- a/charts/common/templates/gateway.yaml
+++ b/charts/common/templates/gateway.yaml
@@ -25,7 +25,6 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - {{ .Values.service.name | default (include "common.name" .) }}
     {{- range .Values.ingress.hosts }}
     - {{ .host | quote }}
     {{- end }}

--- a/charts/common/templates/gateway.yaml
+++ b/charts/common/templates/gateway.yaml
@@ -2,15 +2,12 @@
 {{- if and .Values.ingress.enabled .Values.canary.enabled -}}
 {{- $labels := include "common.labels" . -}}
 {{- $svcport := .Values.service.port -}}
-{{- range .Values.ingress.hosts }}
-{{- $hostwithdashes := printf "%s" .host | replace "." "-" -}}
-{{- $hostwithdashestls := printf "%s-tls" .host | replace "." "-" }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   namespace: {{ $.Values.canary.gatewayNamespace }}
-  name: {{ .name | default $hostwithdashes }}
+  name: {{ include "common.name" . }}
   labels:
     {{- $labels | nindent 4 }}
   {{- if .annotations }}
@@ -38,10 +35,12 @@ spec:
       name: https
       protocol: HTTPS
     hosts:
+    - {{ .Values.service.name | default (include "common.name" .) }}
+    {{- range .Values.ingress.hosts }}
     - {{ .host | quote }}
+    {{- end }}
     tls:
       mode: SIMPLE
       credentialName: {{ .tls.secretName | default $hostwithdashestls }}
     {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/common/templates/gateway.yaml
+++ b/charts/common/templates/gateway.yaml
@@ -28,7 +28,10 @@ spec:
       name: http
       protocol: HTTP
     hosts:
+    - {{ .Values.service.name | default (include "common.name" .) }}
+    {{- range .Values.ingress.hosts }}
     - {{ .host | quote }}
+    {{- end }}
     {{- if .tls }}
   - port:
       number: 443

--- a/charts/common/templates/gateway.yaml
+++ b/charts/common/templates/gateway.yaml
@@ -1,3 +1,4 @@
+{{/* This file is not used now but keeping it in future case of Private gateway applications */}}
 {{- if and .Values.ingress.enabled .Values.canary.enabled -}}
 {{- $labels := include "common.labels" . -}}
 {{- $svcport := .Values.service.port -}}

--- a/charts/common/templates/gateway.yaml
+++ b/charts/common/templates/gateway.yaml
@@ -29,6 +29,7 @@ spec:
     {{- range .Values.ingress.hosts }}
     - {{ .host | quote }}
     {{- end }}
+  {{/*
     {{- if .tls }}
   - port:
       number: 443
@@ -43,4 +44,5 @@ spec:
       mode: SIMPLE
       credentialName: {{ .tls.secretName | default $hostwithdashestls }}
     {{- end }}
+    */}}
 {{- end }}

--- a/charts/common/templates/gateway.yaml
+++ b/charts/common/templates/gateway.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.ingress.enabled .Values.canary -}}
+{{- $labels := include "common.labels" . -}}
+{{- $svcport := .Values.service.port -}}
+{{- range .Values.ingress.hosts }}
+{{- $hostwithdashes := printf "%s" .host | replace "." "-" -}}
+{{- $hostwithdashestls := printf "%s-tls" .host | replace "." "-" }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  namespace: sys
+  name: {{ .name | default $hostwithdashes }}
+  labels:
+    {{- $labels | nindent 4 }}
+  {{- if .annotations }}
+  annotations:
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    istio: gateway-private
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - {{ .host | quote }}
+    {{- if .tls }}
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    - {{ .host | quote }}
+    tls:
+      mode: SIMPLE
+      credentialName: {{ .tls.secretName | default $hostwithdashestls }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/gateway.yaml
+++ b/charts/common/templates/gateway.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.canary -}}
+{{- if and .Values.ingress.enabled .Values.canary.enabled -}}
 {{- $labels := include "common.labels" . -}}
 {{- $svcport := .Values.service.port -}}
 {{- range .Values.ingress.hosts }}
@@ -8,7 +8,7 @@
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
-  namespace: sys
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   name: {{ .name | default $hostwithdashes }}
   labels:
     {{- $labels | nindent 4 }}

--- a/charts/common/templates/hpa-canary.yaml
+++ b/charts/common/templates/hpa-canary.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.autoscaling.enabled .Values.canary.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.name" . }}-canary
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "common.name" . }}
+  minReplicas: {{ .Values.canary.autoscaling.minReplicas | default .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.canary.autoscaling.maxReplicas | default .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  {{- if .Values.hpaBehavior.enabled }}
+  behavior:
+    {{- toYaml .Values.hpaBehavior.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/common/templates/ingress-cloudarmor.yaml
+++ b/charts/common/templates/ingress-cloudarmor.yaml
@@ -11,7 +11,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   {{- if $.Values.canary.enabled }}
-  namespace: sys
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
   name: {{ .name | default $hostwithdashes }}
   labels:
@@ -23,6 +23,7 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: {{ .staticIpName }}
     networking.gke.io/v1beta1.FrontendConfig: {{ $commonname }}
 spec:
+  this: wat
   rules:
   - host: {{ .host | quote }}
     http:
@@ -33,7 +34,9 @@ spec:
           service:
             name: {{ $service.name }}
             port:
-              {{- if $service.port }}
+              {{- if $.Values.canary.enabled }}
+              number: 80
+              {{- else if $service.port }}
               number: {{ $service.port.number }}
               {{- else }}
               number: {{ default $svcport }}
@@ -50,7 +53,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   {{- if $.Values.canary.enabled }}
-  namespace: sys
+  namespace: {{ .Values.canary.gatewayNamespace }}
   {{- end }}
   name: {{ include "common.cloudArmorName" . }}
   labels:
@@ -71,7 +74,9 @@ spec:
           service:
             name: {{ $service.name }}
             port:
-              {{- if $service.port }}
+              {{- if $.Values.canary.enabled }}
+              number: 80
+              {{- else if $service.port }}
               number: {{ $service.port.number }}
               {{- else }}
               number: {{ default $svcport }}

--- a/charts/common/templates/ingress-cloudarmor.yaml
+++ b/charts/common/templates/ingress-cloudarmor.yaml
@@ -23,7 +23,6 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: {{ .staticIpName }}
     networking.gke.io/v1beta1.FrontendConfig: {{ $commonname }}
 spec:
-  this: wat
   rules:
   - host: {{ .host | quote }}
     http:

--- a/charts/common/templates/ingress-cloudarmor.yaml
+++ b/charts/common/templates/ingress-cloudarmor.yaml
@@ -3,10 +3,11 @@
 {{- $svcport := .Values.service.port -}}
 {{- range $ingressStyles }}
 {{- $ingressStyle := . }}
+{{/* cloudArmor.hosts takes priority over cloudArmor.paths */}}
 {{- if hasKey $.Values.cloudArmor "hosts" -}}
-{{- $commonname := include "common.name" . -}}
-{{- $labels := include "common.labels" . -}}
-{{- $secretname := $.Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" .) -}}
+{{- $commonname := include "common.name" $ -}}
+{{- $labels := include "common.labels" $ -}}
+{{- $secretname := $.Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" $) -}}
 {{- range $.Values.cloudArmor.hosts }}
 {{- $hostwithdashes := printf "%s-ca" .host | replace "." "-" }}
 ---
@@ -24,7 +25,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if eq $ingressStyle "csm" }}
-    kubernetes.io/ingress.global-static-ip-name: {{ .meshStaticIpName }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .csmStaticIpName }}
     {{- else }}
     kubernetes.io/ingress.global-static-ip-name: {{ .staticIpName }}
     {{- end }}
@@ -54,6 +55,7 @@ spec:
   tls:
     - secretName: {{ $secretname }}
 {{- end }}
+{{/* Backwards Compatibility with cloudArmor.paths */}}
 {{- else if hasKey $.Values.cloudArmor "paths" }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -70,7 +72,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if eq $ingressStyle "csm" }}
-    kubernetes.io/ingress.global-static-ip-name: {{ $.Values.cloudArmor.meshStaticIpName | default (printf "%s-csm" (include "common.name" $)) }}
+    kubernetes.io/ingress.global-static-ip-name: {{ $.Values.cloudArmor.csmStaticIpName | default (printf "%s-csm" (include "common.name" $)) }}
     {{- else }}
     kubernetes.io/ingress.global-static-ip-name: {{ $.Values.cloudArmor.staticIpName | default (include "common.name" $) }}
     {{- end }}
@@ -98,7 +100,6 @@ spec:
       {{- end }}
   tls:
     - secretName: {{ $.Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" $) }}
-
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}

--- a/charts/common/templates/ingress-cloudarmor.yaml
+++ b/charts/common/templates/ingress-cloudarmor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cloudArmor.enabled (not .Values.canary) -}}
+{{- if .Values.cloudArmor.enabled -}}
 {{- $svcport := .Values.service.port -}}
 {{- if hasKey .Values.cloudArmor "hosts" -}}
 {{- $commonname := include "common.name" . -}}
@@ -10,6 +10,9 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- if $.Values.canary.enabled }}
+  namespace: sys
+  {{- end }}
   name: {{ .name | default $hostwithdashes }}
   labels:
     {{- $labels | nindent 4 }}
@@ -46,6 +49,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- if $.Values.canary.enabled }}
+  namespace: sys
+  {{- end }}
   name: {{ include "common.cloudArmorName" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}

--- a/charts/common/templates/ingress-cloudarmor.yaml
+++ b/charts/common/templates/ingress-cloudarmor.yaml
@@ -1,16 +1,19 @@
 {{- if .Values.cloudArmor.enabled -}}
+{{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
 {{- $svcport := .Values.service.port -}}
-{{- if hasKey .Values.cloudArmor "hosts" -}}
+{{- range $ingressStyles }}
+{{- $ingressStyle := . }}
+{{- if hasKey $.Values.cloudArmor "hosts" -}}
 {{- $commonname := include "common.name" . -}}
 {{- $labels := include "common.labels" . -}}
-{{- $secretname := .Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" .) -}}
-{{- range .Values.cloudArmor.hosts }}
+{{- $secretname := $.Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" .) -}}
+{{- range $.Values.cloudArmor.hosts }}
 {{- $hostwithdashes := printf "%s-ca" .host | replace "." "-" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  {{- if $.Values.canary.enabled }}
+  {{- if eq $ingressStyle "csm" }}
   namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
   name: {{ .name | default $hostwithdashes }}
@@ -20,7 +23,11 @@ metadata:
     {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if eq $ingressStyle "csm" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .meshStaticIpName }}
+    {{- else }}
     kubernetes.io/ingress.global-static-ip-name: {{ .staticIpName }}
+    {{- end }}
     networking.gke.io/v1beta1.FrontendConfig: {{ $commonname }}
 spec:
   rules:
@@ -33,7 +40,7 @@ spec:
           service:
             name: {{ $service.name }}
             port:
-              {{- if $.Values.canary.enabled }}
+              {{- if eq $ingressStyle "csm" }}
               number: 80
               {{- else if $service.port }}
               number: {{ $service.port.number }}
@@ -47,33 +54,38 @@ spec:
   tls:
     - secretName: {{ $secretname }}
 {{- end }}
-{{- else if hasKey .Values.cloudArmor "paths" -}}
+{{- else if hasKey $.Values.cloudArmor "paths" }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  {{- if $.Values.canary.enabled }}
-  namespace: {{ .Values.canary.gatewayNamespace }}
+  {{- if eq $ingressStyle "csm" }}
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
-  name: {{ include "common.cloudArmorName" . }}
+  name: {{ include "common.cloudArmorName" $ }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $ | nindent 4 }}
   annotations:
-    {{- with .Values.cloudArmor.annotations }}
+    {{- with $.Values.cloudArmor.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    kubernetes.io/ingress.global-static-ip-name: {{ .Values.cloudArmor.staticIpName | default (include "common.name" .) }}
-    networking.gke.io/v1beta1.FrontendConfig: {{ include "common.name" . }}
+    {{- if eq $ingressStyle "csm" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ $.Values.cloudArmor.meshStaticIpName | default (printf "%s-csm" (include "common.name" $)) }}
+    {{- else }}
+    kubernetes.io/ingress.global-static-ip-name: {{ $.Values.cloudArmor.staticIpName | default (include "common.name" $) }}
+    {{- end }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "common.name" $ }}
 spec:
   rules:
   - http:
       paths:
-      {{- range .Values.cloudArmor.paths }}
+      {{- range $.Values.cloudArmor.paths }}
       - backend:
         {{- range $backend, $service := .backend }}
           service:
             name: {{ $service.name }}
             port:
-              {{- if $.Values.canary.enabled }}
+              {{- if eq $ingressStyle "csm" }}
               number: 80
               {{- else if $service.port }}
               number: {{ $service.port.number }}
@@ -85,6 +97,8 @@ spec:
         pathType: {{ .pathType | default "ImplementationSpecific" }}
       {{- end }}
   tls:
-    - secretName: {{ .Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" .) }}
+    - secretName: {{ $.Values.cloudArmor.certificate.secretName | default (include "common.cloudArmorTlsSecret" $) }}
+
 {{- end }}
 {{- end }}
+{{- end}}

--- a/charts/common/templates/ingress-cloudarmor.yaml
+++ b/charts/common/templates/ingress-cloudarmor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cloudArmor.enabled -}}
+{{- if and .Values.cloudArmor.enabled (not .Values.canary) -}}
 {{- $svcport := .Values.service.port -}}
 {{- if hasKey .Values.cloudArmor "hosts" -}}
 {{- $commonname := include "common.name" . -}}

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.canary) -}}
 {{- $labels := include "common.labels" . -}}
 {{- $svcport := .Values.service.port -}}
 {{- range .Values.ingress.hosts }}

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled (not .Values.canary) -}}
+{{- if and .Values.ingress.enabled (not .Values.canary.enabled) -}}
 {{- $labels := include "common.labels" . -}}
 {{- $svcport := .Values.service.port -}}
 {{- range .Values.ingress.hosts }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -13,8 +13,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if hasSuffix "-ca" $v.name  }}
-  name: {{ $v.name }}
+  {{- if .Values.canary.enabled -}}
+  namespace: sys
+  {{- end }}
+  {{- if hasSuffix "-ca" .backend.service.name  }}
+  name: {{ .backend.service.name }}
   {{- else }}
   {{- printf "The Service name '%s' does not meet the Cloud Armor naming standards!" $v.name | fail }}
   {{- end }}
@@ -36,6 +39,8 @@ spec:
   selector:
   {{- if $.Values.podSelectorLabelsOverride }}
     {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
+  {{- else if $.Values.canary.enabled }}
+    app.kubernetes.io/name=csm-edgeproxy-public
   {{- else }}
     app.kubernetes.io/name: {{ trimSuffix "-ca" $v.name}}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -2,15 +2,28 @@
 {{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
 {{- $commonname := include "common.name" . -}}
 {{- $labels := include "common.labels" . -}}
+{{- $svcport := .Values.service.port -}}
 {{- $svclist := list }}
-{{- range $k, $v := .Values.cloudArmor.paths -}}
-{{ $svclist = append $svclist $v.backend.service }}
-{{ end }}
-{{- $finallist :=  $svclist | uniq | toYaml -}}
-#{{- $finallist :=  $svclist | uniq  -}}
+
+{{/* cloudArmor.hosts takes priority over cloudArmor.paths */}}
+{{- if hasKey .Values.cloudArmor "hosts" -}}
+  {{- range .Values.cloudArmor.hosts -}}
+    {{- range .paths -}}
+      {{- $svclist = append $svclist .backend.service }}
+    {{- end -}}
+  {{- end -}}
+{{/* Backwards compatibility with cloudArmor.paths */}}
+{{- else if hasKey .Values.cloudArmor "paths" -}}
+  {{- range .Values.cloudArmor.paths -}}
+    {{- $svclist = append $svclist .backend.service }}
+  {{- end -}}
+{{- end -}}
+
+{{- $finallist := $svclist | uniq -}}
+
 {{- range $ingressStyles }}
-{{- $ingressStyle := . }}
-{{- range $k, $v := $finallist }}
+  {{- $ingressStyle := . }}
+  {{- range $svc := $finallist }}
 ---
 apiVersion: v1
 kind: Service
@@ -18,35 +31,36 @@ metadata:
   {{- if eq $ingressStyle "csm" }}
   namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
-  {{- if hasSuffix "-ca" $v.name  }}
-  name: {{ $v.name }}
+  {{- if hasSuffix "-ca" $svc.name }}
+  name: {{ $svc.name }}
   {{- else }}
-  {{- printf "The Service name '%s' does not meet the Cloud Armor naming standards!" $v.name | fail }}
+  {{- printf "The Service name '%s' does not meet the Cloud Armor naming standards!" $svc.name | fail }}
   {{- end }}
   labels:
     {{- $labels | nindent 4 }}
   annotations:
-    {{- if $.Values.cloudArmor.backendConfig.iap }}
-    cloud.google.com/backend-config: '{"ports": {"80":"{{ $commonname }}", "443":"{{ $commonname }}"},"default": "{{ $commonname }}"}'
-    {{- else }}
-    cloud.google.com/backend-config: '{"ports": {"80":"{{ $commonname}}", "443":"{{ $commonname }}"}}'
-    {{- end }}
+    cloud.google.com/backend-config: >
+      {{- if $.Values.cloudArmor.backendConfig.iap }}
+      {"ports": {"80":"{{ $commonname }}", "443":"{{ $commonname }}"},"default": "{{ $commonname }}"}
+      {{- else }}
+      {"ports": {"80":"{{ $commonname }}", "443":"{{ $commonname }}"}}
+      {{- end }}
 spec:
   type: {{ $.Values.cloudArmor.service.type }}
   ports:
-    - port: {{ $v.port.number }}
-      targetPort: {{ if eq $ingressStyle "csm" }}80{{- else }}{{ $v.targetPort | default $.Values.deploymentContainer.port }}{{- end }}
+    - port: {{ $svc.port.number }}
+      targetPort: {{ if eq $ingressStyle "csm" }}80{{- else }}{{ $svc.targetPort | default $.Values.deploymentContainer.port }}{{- end }}
       protocol: TCP
       name: http
   selector:
-  {{- if $.Values.podSelectorLabelsOverride }}
-    {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
-  {{- else if eq $ingressStyle "csm" }}
-    istio: gateway-public
-  {{- else }}
-    app.kubernetes.io/name: {{ trimSuffix "-ca" $v.name}}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- if $.Values.podSelectorLabelsOverride }}
+      {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
+    {{- else if eq $ingressStyle "csm" }}
+      istio: gateway-public
+    {{- else }}
+      app.kubernetes.io/name: {{ trimSuffix "-ca" $svc.name }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -9,16 +9,12 @@
 {{- $finallist :=  $svclist | uniq | toYaml -}}
 #{{- $finallist :=  $svclist | uniq  -}}
 {{- range $k, $v := $finallist }}
-
-=======
-{{- range .Values.cloudArmor.paths }}
->>>>>>> 8c836a3 (wip)
 ---
 apiVersion: v1
 kind: Service
 metadata:
   {{- if $.Values.canary.enabled }}
-  namespace: sys
+  namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
   {{- if hasSuffix "-ca" $v.name  }}
   name: {{ $v.name }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.cloudArmor.enabled -}}
+{{- $ingressStyles := fromJsonArray (include "ingressStyles" .) }}
 {{- $commonname := include "common.name" . -}}
 {{- $labels := include "common.labels" . -}}
 {{- $svclist := list }}
@@ -7,12 +8,14 @@
 {{ end }}
 {{- $finallist :=  $svclist | uniq | toYaml -}}
 #{{- $finallist :=  $svclist | uniq  -}}
+{{- range $ingressStyles }}
+{{- $ingressStyle := . }}
 {{- range $k, $v := $finallist }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if $.Values.canary.enabled }}
+  {{- if eq $ingressStyle "csm" }}
   namespace: {{ $.Values.canary.gatewayNamespace }}
   {{- end }}
   {{- if hasSuffix "-ca" $v.name  }}
@@ -32,17 +35,18 @@ spec:
   type: {{ $.Values.cloudArmor.service.type }}
   ports:
     - port: {{ $v.port.number }}
-      targetPort: {{ if $.Values.canary.enabled }}80{{- else }}{{ $v.targetPort | default $.Values.deploymentContainer.port }}{{- end }}
+      targetPort: {{ if eq $ingressStyle "csm" }}80{{- else }}{{ $v.targetPort | default $.Values.deploymentContainer.port }}{{- end }}
       protocol: TCP
       name: http
   selector:
   {{- if $.Values.podSelectorLabelsOverride }}
     {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
-  {{- else if $.Values.canary.enabled }}
+  {{- else if eq $ingressStyle "csm" }}
     istio: gateway-public
   {{- else }}
     app.kubernetes.io/name: {{ trimSuffix "-ca" $v.name}}
     app.kubernetes.io/instance: {{ $.Release.Name }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -39,7 +39,7 @@ spec:
   {{- if $.Values.podSelectorLabelsOverride }}
     {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
   {{- else if $.Values.canary.enabled }}
-    app.kubernetes.io/name: csm-edgeproxy-public
+    istio: gateway-public
   {{- else }}
     app.kubernetes.io/name: {{ trimSuffix "-ca" $v.name}}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.cloudArmor.enabled -}}
 {{- $commonname := include "common.name" . -}}
 {{- $labels := include "common.labels" . -}}
-<<<<<<< HEAD
 {{- $svclist := list }}
 {{- range $k, $v := .Values.cloudArmor.paths -}}
 {{ $svclist = append $svclist $v.backend.service }}
@@ -32,7 +31,7 @@ metadata:
 spec:
   type: {{ $.Values.cloudArmor.service.type }}
   ports:
-    - port: {{ .backend.service.port.number }}
+    - port: {{ $v.port.number }}
       targetPort: {{ if $.Values.canary.enabled }}80{{- else }}{{ $v.targetPort | default $.Values.deploymentContainer.port }}{{- end }}
       protocol: TCP
       name: http

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.cloudArmor.enabled -}}
 {{- $commonname := include "common.name" . -}}
 {{- $labels := include "common.labels" . -}}
+<<<<<<< HEAD
 {{- $svclist := list }}
 {{- range $k, $v := .Values.cloudArmor.paths -}}
 {{ $svclist = append $svclist $v.backend.service }}
@@ -9,15 +10,18 @@
 #{{- $finallist :=  $svclist | uniq  -}}
 {{- range $k, $v := $finallist }}
 
+=======
+{{- range .Values.cloudArmor.paths }}
+>>>>>>> 8c836a3 (wip)
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.canary.enabled -}}
+  {{- if $.Values.canary.enabled }}
   namespace: sys
   {{- end }}
-  {{- if hasSuffix "-ca" .backend.service.name  }}
-  name: {{ .backend.service.name }}
+  {{- if hasSuffix "-ca" $v.name  }}
+  name: {{ $v.name }}
   {{- else }}
   {{- printf "The Service name '%s' does not meet the Cloud Armor naming standards!" $v.name | fail }}
   {{- end }}
@@ -32,15 +36,15 @@ metadata:
 spec:
   type: {{ $.Values.cloudArmor.service.type }}
   ports:
-    - port: {{ $v.port.number }}
-      targetPort: {{ $v.targetPort | default $.Values.deploymentContainer.port }}
+    - port: {{ .backend.service.port.number }}
+      targetPort: {{ if $.Values.canary.enabled }}80{{- else }}{{ $v.targetPort | default $.Values.deploymentContainer.port }}{{- end }}
       protocol: TCP
       name: http
   selector:
   {{- if $.Values.podSelectorLabelsOverride }}
     {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
   {{- else if $.Values.canary.enabled }}
-    app.kubernetes.io/name=csm-edgeproxy-public
+    app.kubernetes.io/name: csm-edgeproxy-public
   {{- else }}
     app.kubernetes.io/name: {{ trimSuffix "-ca" $v.name}}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/common/templates/virtualservice.yaml
+++ b/charts/common/templates/virtualservice.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.canary.enabled -}}
+{{- $canaryWeight := .Values.canary.weight | default 5 }}
+{{- $remainingWeight := sub 100 $canaryWeight }}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "common.name" . }}-mesh
+spec:
+  hosts:
+  - {{ .Values.service.name | default (include "common.name" .) }}
+  http:
+  - route:
+    - destination:
+        host: {{ .Values.service.name | default (include "common.name" .) }}
+        subset: canary
+      weight: {{ $canaryWeight }}
+    - destination:
+        host: {{ .Values.service.name | default (include "common.name" .) }}
+        subset: production
+      weight: {{ $remainingWeight }}
+{{- end }}

--- a/charts/common/templates/virtualservice.yaml
+++ b/charts/common/templates/virtualservice.yaml
@@ -12,13 +12,19 @@ spec:
   {{- if .Values.ingress.enabled }}
   - {{ .Values.canary.gatewayNamespace}}/{{ .Values.service.name | default (include "common.name" .) }}
   {{ end }}
-  {{- if .Values.cloudArmor.enabled -}}
+  {{- if .Values.cloudArmor.enabled }}
   - {{ .Values.canary.gatewayNamespace}}/{{ .Values.service.name | default (include "common.name" .) }}-ca
   {{ end }}
   hosts:
   - {{ .Values.service.name | default (include "common.name" .) }}
-  {{- range .Values.ingress.hosts }}
+  {{- if .Values.cloudArmor.enabled -}}
+  {{- range .Values.cloudArmor.hosts }}
   - {{ .host | quote }}
+  {{- end }}
+  - {{ .Values.cloudArmor.certificate.host | quote }}
+  {{- range  .Values.cloudArmor.certificate.alternativeDnsNames }}
+  - {{ . | quote }}
+  {{- end }}
   {{- end }}
   http:
   - route:

--- a/charts/common/templates/virtualservice.yaml
+++ b/charts/common/templates/virtualservice.yaml
@@ -10,8 +10,11 @@ spec:
   gateways:
   - mesh
   {{- if .Values.ingress.enabled }}
-  - sys/{{ .Values.service.name | default (include "common.name" .) }}
-  {{- end }}
+  - {{ .Values.canary.gatewayNamespace}}/{{ .Values.service.name | default (include "common.name" .) }}
+  {{ end }}
+  {{- if .Values.cloudArmor.enabled -}}
+  - {{ .Values.canary.gatewayNamespace}}/{{ .Values.service.name | default (include "common.name" .) }}-ca
+  {{ end }}
   hosts:
   - {{ .Values.service.name | default (include "common.name" .) }}
   {{- range .Values.ingress.hosts }}

--- a/charts/common/templates/virtualservice.yaml
+++ b/charts/common/templates/virtualservice.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.canary.enabled -}}
 {{- $canaryWeight := .Values.canary.weight | default 5 }}
-{{- $remainingWeight := sub 100 $canaryWeight }}
+{{- $effectiveCanaryWeight := min (max $canaryWeight 0) 100 }}
+{{- $remainingWeight := sub 100 $effectiveCanaryWeight }}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -13,7 +14,7 @@ spec:
     - destination:
         host: {{ .Values.service.name | default (include "common.name" .) }}
         subset: canary
-      weight: {{ $canaryWeight }}
+      weight: {{ $effectiveCanaryWeight }}
     - destination:
         host: {{ .Values.service.name | default (include "common.name" .) }}
         subset: production

--- a/charts/common/templates/virtualservice.yaml
+++ b/charts/common/templates/virtualservice.yaml
@@ -5,10 +5,18 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: {{ include "common.name" . }}-mesh
+  name: {{ .Values.service.name | default (include "common.name" .) }}
 spec:
+  gateways:
+  - mesh
+  {{- if .Values.ingress.enabled }}
+  - sys/{{ .Values.service.name | default (include "common.name" .) }}
+  {{- end }}
   hosts:
   - {{ .Values.service.name | default (include "common.name" .) }}
+  {{- range .Values.ingress.hosts }}
+  - {{ .host | quote }}
+  {{- end }}
   http:
   - route:
     - destination:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -202,7 +202,7 @@ cloudArmor:
   #     # The name is optional, If not set, a name is generated using host
   #     # name: ""
   #     staticIpName: ""
-  #     meshStaticIpName: "" # Only used if canary.enabled is true
+  #     csmStaticIpName: "" # Only used if canary.enabled is true, If not set, a name is generated using Release.Name with "-csm" suffix
   #     annotations: {}
   #       # kubernetes.io/ingress.class: (nginx-internal or nginx-public)
   #       # kubernetes.io/tls-acme: "true"
@@ -242,7 +242,7 @@ cloudArmor:
       responseCodeName: PERMANENT_REDIRECT
   # staticIpName is optional, If not set, a name is generated using Release.Name. This is a resource in GCP.
   # staticIpName: ""
-  # meshStaticIpName: "" # Only used if canary.enabled is true. Optional, If not set, a name is generated using Release.Name with "-csm" suffix. This is a resource in GCP.
+  # csmStaticIpName: "" # Only used if canary.enabled is true. Optional, If not set, a name is generated using Release.Name with "-csm" suffix. This is a resource in GCP.
   # cloudArmor needs a service type NodePort
   service:
     type: NodePort

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -144,6 +144,13 @@ service:
   # The name of the service is optional, If not set, a name is generated using Release.Name
   # name: ""
 
+canary:
+  enabled: false
+  # percentage of traffic that should be sent to canary. (100 - weight) is sent to non-canary deployment.
+  # weight: 5
+  # image:
+  #  tag: ""
+
 ingress:
   enabled: false
   hosts:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -147,6 +147,7 @@ service:
 canary:
   enabled: false
   gatewayNamespace: istio-ingress
+  migration: true
   # percentage of traffic that should be sent to canary. (100 - weight) is sent to non-canary deployment.
   # weight: 5
   # image:
@@ -195,6 +196,7 @@ cloudArmor:
   #     # The name is optional, If not set, a name is generated using host
   #     # name: ""
   #     staticIpName: ""
+  #     meshStaticIpName: "" # Only used if canary.enabled is true
   #     annotations: {}
   #       # kubernetes.io/ingress.class: (nginx-internal or nginx-public)
   #       # kubernetes.io/tls-acme: "true"
@@ -234,6 +236,7 @@ cloudArmor:
       responseCodeName: PERMANENT_REDIRECT
   # staticIpName is optional, If not set, a name is generated using Release.Name. This is a resource in GCP.
   # staticIpName: ""
+  # meshStaticIpName: "" # Only used if canary.enabled is true. Optional, If not set, a name is generated using Release.Name with "-csm" suffix. This is a resource in GCP.
   # cloudArmor needs a service type NodePort
   service:
     type: NodePort

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -147,7 +147,13 @@ service:
 canary:
   enabled: false
   gatewayNamespace: istio-ingress
+  # if set to true (default), then two sets of Cloud Armor-related resources are created: one for "legacy" and one for "cloud service mesh" aka "canary"
   migration: true
+  # HPA settings for canary deployment. ".Values.autoscaling" values are used to confiugre HPA.
+  # minReplicas and/or maxReplicas can be overriten for canary with this configuration. Does not support overriding any other values. 
+  # autoscaling:
+  #  minReplicas: 1 (defaults to .Values.autoscaling.minReplicas)
+  #  maxReplicas: 10 (defaults to .Values.autoscaling.maxReplicas)
   # percentage of traffic that should be sent to canary. (100 - weight) is sent to non-canary deployment.
   # weight: 5
   # image:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -146,7 +146,7 @@ service:
 
 canary:
   enabled: false
-  gatewayNamespace: sys
+  gatewayNamespace: istio-ingress
   # percentage of traffic that should be sent to canary. (100 - weight) is sent to non-canary deployment.
   # weight: 5
   # image:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -146,6 +146,7 @@ service:
 
 canary:
   enabled: false
+  gatewayNamespace: sys
   # percentage of traffic that should be sent to canary. (100 - weight) is sent to non-canary deployment.
   # weight: 5
   # image:


### PR DESCRIPTION
Adds concept of canary to run side-by-side with existing setup. 

This has been tested in devel-2 cluster in different states: "legacy", "canary + internal lb", "canary + CloudArmor". 

Added the concept of "canary migration" to the chart. Concept only relevant to applications that use CloudArmor.

If `canary.migration` is true, then two CA sets of resources are generated: one for "legacy" (i.e. the way it before this PR) and one for "Cloud Service Mesh". This is due to resources being deployed to a different namespaces.