### PR TITLE
SRE-5480/cloudsqlproxy

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0-beta.2
+version: 0.9.0-beta.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -106,12 +106,12 @@ This variable will be used in deployment.yaml and workflowtemplate.yaml it's a s
 Once all apps are using cloud sql proxy v2 this can be simplified.
 */}}
 {{- define "common.instanceConnectionName" -}}
-{{- if .Values.cloudsqlProxy.enabled -}}
-  {{- if .Values.cloudsqlProxy.instanceConnectionName -}}
-    {{- .Values.cloudsqlProxy.instanceConnectionName  -}}
-  {{- else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName -}}
-    {{- .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName  -}}
-  {{- else if .Values.cloudsqlProxy.command -}}
+{{- if .Values.cloudsqlProxy.instanceConnectionName -}}
+  {{- .Values.cloudsqlProxy.instanceConnectionName  -}}
+{{- else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName -}}
+  {{- .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName  -}}
+{{- else if .Values.cloudsqlProxy.enabled -}}
+  {{- if .Values.cloudsqlProxy.command -}}
     {{- $commandList := .Values.cloudsqlProxy.command -}}
     {{- $instanceArg := "" -}}
     {{- range $cmd := $commandList -}}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -107,9 +107,9 @@ Once all apps are using cloud sql proxy v2 this can be simplified.
 */}}
 {{- define "common.instanceConnectionName" -}}
 {{- if .Values.cloudsqlProxy.instanceConnectionName -}}
-  {{- .Values.cloudsqlProxy.instanceConnectionName  -}}
+  {{- .Values.cloudsqlProxy.instanceConnectionName -}}
 {{- else if .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName -}}
-  {{- .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName  -}}
+  {{- .Values.cloudsqlProxy.migrationTemplate.instanceConnectionName -}}
 {{- else if .Values.cloudsqlProxy.enabled -}}
   {{- if .Values.cloudsqlProxy.command -}}
     {{- $commandList := .Values.cloudsqlProxy.command -}}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -58,12 +58,12 @@ spec:
       name: http
   selector:
     {{- if $.Values.podSelectorLabelsOverride }}
-      {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
+    {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
     {{- else if eq $ingressStyle "csm" }}
-      istio: gateway-public
+    istio: gateway-public
     {{- else }}
-      app.kubernetes.io/name: {{ trimSuffix "-ca" $svc.name }}
-      app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/name: {{ trimSuffix "-ca" $svc.name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**Ticket**
[SRE-5480](https://demoforthedaves.atlassian.net/browse/SRE-5480)

**Ticket and brief summary**
- Allow reading definition of `instanceConnectionName` even if `cloudsqlProxy.enabled` is false
- Address space/ident in `service.yaml`

**How did you test your code?**
```
diff 0.8.9.yaml 0.9.0-beta.3.yaml                                                                              ✔ 
8c8
<     helm.sh/chart: user-accounts-api-0.8.9
---
>     helm.sh/chart: user-accounts-api-0.9.0-beta.3
24c24
<     helm.sh/chart: user-accounts-api-0.8.9
---
>     helm.sh/chart: user-accounts-api-0.9.0-beta.3
48c48
<     helm.sh/chart: user-accounts-api-0.8.9
---
>     helm.sh/chart: user-accounts-api-0.9.0-beta.3
56c56,57
<     cloud.google.com/backend-config: '{"ports": {"80":"user-accounts-api", "443":"user-accounts-api"}}'
---
>     cloud.google.com/backend-config: >
>       {"ports": {"80":"user-accounts-api", "443":"user-accounts-api"}}
75c76
<     helm.sh/chart: user-accounts-api-0.8.9
---
>     helm.sh/chart: user-accounts-api-0.9.0-beta.3
101c102
<     helm.sh/chart: user-accounts-api-0.8.9
---
>     helm.sh/chart: user-accounts-api-0.9.0-beta.3
123a125
>         canary: "false"
244c246
<     helm.sh/chart: user-accounts-api-0.8.9
---
>     helm.sh/chart: user-accounts-api-0.9.0-beta.3
272c274
<     helm.sh/chart: user-accounts-api-0.8.9
---
>     helm.sh/chart: user-accounts-api-0.9.0-beta.3
380c382
<       command: ["/cloud_sql_proxy","-instances==tcp:0.0.0.0:3306"]
---
>       command: ["/cloud_sql_proxy","-instances=internal-1-4825:us-central1:staging-2=tcp:0.0.0.0:3306"]
```

**How will you confirm this change is working once it's deployed?**

[SRE-5480]: https://demoforthedaves.atlassian.net/browse/SRE-5480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ