### PR TITLE
[SRE-5728] feat: Bump cloudsql-proxy chart version to 0.1.1-beta.0 and add schema validation

### DIFF
--- a/charts/cloudsql-proxy/Chart.yaml
+++ b/charts/cloudsql-proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1-beta.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudsql-proxy/schemas/schema.yaml
+++ b/charts/cloudsql-proxy/schemas/schema.yaml
@@ -1,0 +1,8 @@
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+properties:
+  replicaCount:
+    type: integer
+    minimum: 1
+required:
+  - replicaCount

--- a/charts/cloudsql-proxy/values.schema.json
+++ b/charts/cloudsql-proxy/values.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    }
+  },
+  "required": [
+    "replicaCount"
+  ]
+}


### PR DESCRIPTION
**Ticket**
[SRE-5728](https://demoforthedaves.atlassian.net/browse/SRE-5728)

**Ticket and brief summary**
- feat: Bump cloudsql-proxy chart version to 0.1.1-beta.0 and add schema validation

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[SRE-5728]: https://demoforthedaves.atlassian.net/browse/SRE-5728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ