### PR TITLE
[BEI-1120] Passthrough XFF headers as is in rproxy

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2-beta.2
+version: 0.10.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2-beta.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/configmap-rproxy.yaml
+++ b/charts/common/templates/configmap-rproxy.yaml
@@ -64,8 +64,8 @@ data:
       location / {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwaded_proto;
         proxy_set_header Connection "";
         proxy_http_version 1.1;
         


### PR DESCRIPTION
<!-- **PR Name format example**
[SRE-18] - Description

Where SRE is replaced with the appropriate JIRA project prefix and the 18 is the ticket number.
-->

**Ticket**
[BEI-1120](https://demoforthedaves.atlassian.net/browse/BEI-1120)

**Ticket and brief summary**

Configure nginx to keep X-Forwaded-For and X-Forwaded-Proto as is rather than appending itself to it.

**How did you test your code?**

In bff-staging

**How will you confirm this change is working once it's deployed?**


[SRE-18]: https://demoforthedaves.atlassian.net/browse/SRE-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BEI-1120]: https://demoforthedaves.atlassian.net/browse/BEI-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ