### PR TITLE
BEI-1153 - Improve handling of cloudarmor canary logic

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.3
+version: 0.10.4-beta1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.4-beta1
+version: 0.10.4-beta2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.4-beta2
+version: 0.10.4
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/common/templates/deployment-canary.yaml
+++ b/charts/common/templates/deployment-canary.yaml
@@ -10,7 +10,7 @@
 ) -}}
 {{- $imageTag := .Values.image.tag   }}
 {{- if and .Values.canary.image .Values.canary.image.tag }}
-{{- $imageTag := .Values.canary.image.tag }}
+{{- $imageTag = .Values.canary.image.tag }}
 {{- end }}
 {{- $sqlProxyVersion := include "common.cloudsqlProxyVersion" . -}}
 {{- $sqlinstanceConnectionName := include "common.instanceConnectionName" . -}}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -51,7 +51,7 @@ spec:
       name: http
   selector:
   {{- $caRootName := trimSuffix "-ca" $svc.name -}}
-  {{- $commonName := include "common.name" $ -}}
+  {{- $commonname := include "common.name" $ -}}
   {{- $isCanary := false -}}
   {{- if kindIs "bool" $svc.canary -}}
     {{- $isCanary = $svc.canary -}}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -50,22 +50,22 @@ spec:
       protocol: TCP
       name: http
   selector:
-  {{- $caRootName := trimSuffix "-ca" $svc.name -}}
+  {{- $svcRootName := trimSuffix "-ca" $svc.name -}}
   {{- $commonname := include "common.name" $ -}}
   {{- $isCanary := false -}}
   {{- if kindIs "bool" $svc.canary -}}
     {{- $isCanary = $svc.canary -}}
-  {{- else if and $.Values.canary (kindIs "bool" $.Values.canary.enabled) (eq $caRootName $commonname) -}}
+  {{- else if and $.Values.canary (kindIs "bool" $.Values.canary.enabled) (eq $svcRootName $commonname) -}}
     {{- $isCanary = $.Values.canary.enabled -}}
   {{- end -}}
   
   {{- if $isCanary }}
-    app.kubernetes.io/name: {{ printf "%s-rproxy" $caRootName }}
+    app.kubernetes.io/name: {{ printf "%s-rproxy" $svcRootName }}
     app.kubernetes.io/instance: {{ printf "%s-rproxy" $.Release.Name }}
   {{- else if $.Values.podSelectorLabelsOverride }}
     {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
   {{- else }}
-    app.kubernetes.io/name: {{ $caRootName }}
+    app.kubernetes.io/name: {{ $svcRootName }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
   {{- end }}
 {{- end }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -50,16 +50,21 @@ spec:
       protocol: TCP
       name: http
   selector:
-  {{- if $svc.canary }}
+  {{- $isCanary := false -}}
+  {{- if hasKey $svc "canary" -}}
+    {{- $isCanary = $svc.canary -}}
+  {{- else -}}
+    {{- $isCanary = $.Values.canary.enabled -}}
+  {{- end -}}
+  
+  {{- if $isCanary }}
     app.kubernetes.io/name: {{ printf "%s-rproxy" (trimSuffix "-ca" $svc.name) }}
     app.kubernetes.io/instance: {{ printf "%s-rproxy" $.Release.Name }}
-  {{- else}}
-    {{- if $.Values.podSelectorLabelsOverride }}
-      {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
-    {{- else }}
+  {{- else if $.Values.podSelectorLabelsOverride }}
+    {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
+  {{- else }}
     app.kubernetes.io/name: {{ trimSuffix "-ca" $svc.name}}
     app.kubernetes.io/instance: {{ $.Release.Name }}
-    {{- end }}
-  {{- end}}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -51,9 +51,9 @@ spec:
       name: http
   selector:
   {{- $isCanary := false -}}
-  {{- if hasKey $svc "canary" -}}
+  {{- if kindIs "bool" $svc.canary -}}
     {{- $isCanary = $svc.canary -}}
-  {{- else -}}
+  {{- else if and $.Values.canary (kindIs "bool" $.Values.canary.enabled) -}}
     {{- $isCanary = $.Values.canary.enabled -}}
   {{- end -}}
   

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -50,20 +50,22 @@ spec:
       protocol: TCP
       name: http
   selector:
+  {{- $caRootName := trimSuffix "-ca" $svc.name -}}
+  {{- $commonName := include "common.name" $ -}}
   {{- $isCanary := false -}}
   {{- if kindIs "bool" $svc.canary -}}
     {{- $isCanary = $svc.canary -}}
-  {{- else if and $.Values.canary (kindIs "bool" $.Values.canary.enabled) -}}
+  {{- else if and $.Values.canary (and (kindIs "bool" $.Values.canary.enabled) (eq $caRootName $commonname)) -}}
     {{- $isCanary = $.Values.canary.enabled -}}
   {{- end -}}
   
   {{- if $isCanary }}
-    app.kubernetes.io/name: {{ printf "%s-rproxy" (trimSuffix "-ca" $svc.name) }}
+    app.kubernetes.io/name: {{ printf "%s-rproxy" $caRootName }}
     app.kubernetes.io/instance: {{ printf "%s-rproxy" $.Release.Name }}
   {{- else if $.Values.podSelectorLabelsOverride }}
     {{- $.Values.podSelectorLabelsOverride | toYaml | nindent 4 }}
   {{- else }}
-    app.kubernetes.io/name: {{ trimSuffix "-ca" $svc.name}}
+    app.kubernetes.io/name: {{ $caRootName }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
   {{- end }}
 {{- end }}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -51,7 +51,6 @@ spec:
       name: http
   selector:
   {{- $svcRootName := trimSuffix "-ca" $svc.name -}}
-  {{- $commonname := include "common.name" $ -}}
   {{- $isCanary := false -}}
   {{- if kindIs "bool" $svc.canary -}}
     {{- $isCanary = $svc.canary -}}

--- a/charts/common/templates/service-cloudarmor.yaml
+++ b/charts/common/templates/service-cloudarmor.yaml
@@ -55,7 +55,7 @@ spec:
   {{- $isCanary := false -}}
   {{- if kindIs "bool" $svc.canary -}}
     {{- $isCanary = $svc.canary -}}
-  {{- else if and $.Values.canary (and (kindIs "bool" $.Values.canary.enabled) (eq $caRootName $commonname)) -}}
+  {{- else if and $.Values.canary (kindIs "bool" $.Values.canary.enabled) (eq $caRootName $commonname) -}}
     {{- $isCanary = $.Values.canary.enabled -}}
   {{- end -}}
   

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -81,8 +81,7 @@
                               "maximum": 65535
                             },
                             "canary": {
-                              "type": "boolean",
-                              "default": false
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -156,8 +155,7 @@
                         "maximum": 65535
                       },
                       "canary": {
-                        "type": "boolean",
-                        "default": false
+                        "type": "boolean"
                       }
                     },
                     "required": [


### PR DESCRIPTION
<!-- **PR Name format example**
[SRE-18] - Description

Where SRE is replaced with the appropriate JIRA project prefix and the 18 is the ticket number.
-->

**Ticket**
https://demoforthedaves.atlassian.net/browse/BEI-1153

**Ticket and brief summary**
If "canary" is provided on the cloudarmor service section, I want to use that boolean value, even if it is set to false. Only fallback to using the parent chart canary.enabled value if canary is NOT provided in the cloudarmor section.

**How did you test your code?**
helm template locally for all scenarios

**How will you confirm this change is working once it's deployed?**
Attempt using with notification-service first


[SRE-18]: https://demoforthedaves.atlassian.net/browse/SRE-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DAVE-1]: https://demoforthedaves.atlassian.net/browse/DAVE-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ