### PR TITLE
SRE-6035: Add standalone cloudarmor Helm chart v0.1.0

### DIFF
--- a/charts/cloudarmor/.helmignore
+++ b/charts/cloudarmor/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.idea/
+.vscode/
+*.tmproj
+*.project
+.classpath
+.settings/

--- a/charts/cloudarmor/Chart.yaml
+++ b/charts/cloudarmor/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cloudarmor
+description: GKE Ingress with Cloud Armor (BackendConfig, FrontendConfig, Certificate, CA Services, Ingress). Deploy separately from service charts; backends reference app pods by selector.
+type: application
+version: 0.2.0
+appVersion: 0.2.0

--- a/charts/cloudarmor/Chart.yaml
+++ b/charts/cloudarmor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cloudarmor
 description: GKE Ingress with Cloud Armor (BackendConfig, FrontendConfig, Certificate, CA Services, Ingress). Deploy separately from service charts; backends reference app pods by selector.
 type: application
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.1.1
+appVersion: 0.1.0

--- a/charts/cloudarmor/templates/_helpers.tpl
+++ b/charts/cloudarmor/templates/_helpers.tpl
@@ -1,5 +1,6 @@
 {{/*
-Cloud Armor chart name (BackendConfig / FrontendConfig).
+Cloud Armor chart name (BackendConfig / FrontendConfig / Certificate).
+Defaults to .Release.Name if .Values.name is not set.
 */}}
 {{- define "cloudarmor.name" -}}
 {{- default .Release.Name .Values.name | trunc 63 | trimSuffix "-" }}
@@ -17,8 +18,14 @@ TLS secret name for certificate.
 {{- end }}
 
 {{/*
-Default backend port for ingress when not specified per path.
+Common Helm labels (applied to all resources).
 */}}
-{{- define "cloudarmor.defaultBackendPort" -}}
-80
+{{- define "cloudarmor.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "cloudarmor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 {{- end }}

--- a/charts/cloudarmor/templates/_helpers.tpl
+++ b/charts/cloudarmor/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/*
+Cloud Armor chart name (BackendConfig / FrontendConfig).
+*/}}
+{{- define "cloudarmor.name" -}}
+{{- default .Release.Name .Values.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+TLS secret name for certificate.
+*/}}
+{{- define "cloudarmor.tlsSecret" -}}
+{{- if .Values.certificate.secretName }}
+{{- .Values.certificate.secretName }}
+{{- else }}
+{{- printf "%s-ca-tls" .Values.certificate.host | replace "." "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Default backend port for ingress when not specified per path.
+*/}}
+{{- define "cloudarmor.defaultBackendPort" -}}
+80
+{{- end }}

--- a/charts/cloudarmor/templates/backendconfig.yaml
+++ b/charts/cloudarmor/templates/backendconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ include "cloudarmor.name" . }}
+  {{- with .Values.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml .Values.backendConfig | nindent 2 }}

--- a/charts/cloudarmor/templates/backendconfig.yaml
+++ b/charts/cloudarmor/templates/backendconfig.yaml
@@ -2,9 +2,10 @@ apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ include "cloudarmor.name" . }}
-  {{- with .Values.labels }}
   labels:
+    {{- include "cloudarmor.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- toYaml .Values.backendConfig | nindent 2 }}

--- a/charts/cloudarmor/templates/certificate.yaml
+++ b/charts/cloudarmor/templates/certificate.yaml
@@ -1,11 +1,17 @@
+{{/*
+A single Certificate is created for the host defined in certificate.host.
+If using ingress.hosts mode with multiple hostnames, add the additional hosts
+to certificate.alternativeDnsNames so they are covered by this certificate.
+*/}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "cloudarmor.name" . }}
-  {{- with .Values.labels }}
   labels:
+    {{- include "cloudarmor.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   secretName: {{ include "cloudarmor.tlsSecret" . }}
   issuerRef:

--- a/charts/cloudarmor/templates/certificate.yaml
+++ b/charts/cloudarmor/templates/certificate.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cloudarmor.name" . }}
+  {{- with .Values.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "cloudarmor.tlsSecret" . }}
+  issuerRef:
+    kind: ClusterIssuer
+    name: {{ .Values.certificate.issuer | default "letsencrypt" }}
+  commonName: {{ .Values.certificate.host | quote }}
+  dnsNames:
+    - {{ .Values.certificate.host | quote }}
+  {{- with .Values.certificate.alternativeDnsNames }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/cloudarmor/templates/frontendconfig.yaml
+++ b/charts/cloudarmor/templates/frontendconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ include "cloudarmor.name" . }}
+  {{- with .Values.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml .Values.frontendConfig | nindent 2 }}

--- a/charts/cloudarmor/templates/frontendconfig.yaml
+++ b/charts/cloudarmor/templates/frontendconfig.yaml
@@ -2,9 +2,10 @@ apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
   name: {{ include "cloudarmor.name" . }}
-  {{- with .Values.labels }}
   labels:
+    {{- include "cloudarmor.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- toYaml .Values.frontendConfig | nindent 2 }}

--- a/charts/cloudarmor/templates/ingress.yaml
+++ b/charts/cloudarmor/templates/ingress.yaml
@@ -8,10 +8,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name | default (printf "%s-ca" .host | replace "." "-") }}
-  {{- with $.Values.labels }}
   labels:
+    {{- include "cloudarmor.labels" $ | nindent 4 }}
+    {{- with $.Values.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
   annotations:
     {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
@@ -41,10 +42,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "cloudarmor.name" . }}-ca
-  {{- with .Values.labels }}
   labels:
+    {{- include "cloudarmor.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
   annotations:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/cloudarmor/templates/ingress.yaml
+++ b/charts/cloudarmor/templates/ingress.yaml
@@ -1,0 +1,69 @@
+{{- $frontendConfigName := include "cloudarmor.name" . }}
+{{- $tlsSecretName := include "cloudarmor.tlsSecret" . }}
+{{/* hosts takes priority over paths */}}
+{{- if .Values.ingress.hosts }}
+{{- range .Values.ingress.hosts }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .name | default (printf "%s-ca" .host | replace "." "-") }}
+  {{- with $.Values.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .staticIpName }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ $frontendConfigName }}
+spec:
+  rules:
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ .path | default "/*" }}
+        pathType: {{ .pathType | default "ImplementationSpecific" }}
+        backend:
+          service:
+            name: {{ .backendServiceName }}
+            port:
+              number: {{ .backendPort | default 80 }}
+      {{- end }}
+  tls:
+    - secretName: {{ $tlsSecretName }}
+{{- end }}
+{{- else if .Values.ingress.paths }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cloudarmor.name" . }}-ca
+  {{- with .Values.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.staticIpName | default (include "cloudarmor.name" .) }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ $frontendConfigName }}
+spec:
+  rules:
+  - http:
+      paths:
+      {{- range .Values.ingress.paths }}
+      - path: {{ .path | default "/*" }}
+        pathType: {{ .pathType | default "ImplementationSpecific" }}
+        backend:
+          service:
+            name: {{ .backendServiceName }}
+            port:
+              number: {{ .backendPort | default 80 }}
+      {{- end }}
+  tls:
+    - secretName: {{ $tlsSecretName }}
+{{- end }}

--- a/charts/cloudarmor/templates/service.yaml
+++ b/charts/cloudarmor/templates/service.yaml
@@ -1,0 +1,27 @@
+{{- $backendConfigName := include "cloudarmor.name" . }}
+{{- range .Values.backends }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .serviceName }}
+  {{- with $.Values.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    cloud.google.com/backend-config: '{"ports": {"{{ .port }}":"{{ $backendConfigName }}"}}'
+{{- if .iap }}
+    cloud.google.com/backend-config: '{"ports": {"{{ .port }}":"{{ $backendConfigName }}"}, "default":"{{ $backendConfigName }}"}'
+{{- end }}
+spec:
+  type: {{ .serviceType | default "NodePort" }}
+  ports:
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- toYaml .selector | nindent 4 }}
+{{- end }}

--- a/charts/cloudarmor/templates/service.yaml
+++ b/charts/cloudarmor/templates/service.yaml
@@ -5,16 +5,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .serviceName }}
-  {{- with $.Values.labels }}
   labels:
+    {{- include "cloudarmor.labels" $ | nindent 4 }}
+    {{- with $.Values.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
-    cloud.google.com/backend-config: '{"ports": {"{{ .port }}":"{{ $backendConfigName }}"}}'
-{{- if .iap }}
+    {{- if .iap }}
     cloud.google.com/backend-config: '{"ports": {"{{ .port }}":"{{ $backendConfigName }}"}, "default":"{{ $backendConfigName }}"}'
-{{- end }}
+    {{- else }}
+    cloud.google.com/backend-config: '{"ports": {"{{ .port }}":"{{ $backendConfigName }}"}}'
+    {{- end }}
 spec:
   type: {{ .serviceType | default "NodePort" }}
   ports:

--- a/charts/cloudarmor/values.yaml
+++ b/charts/cloudarmor/values.yaml
@@ -1,0 +1,70 @@
+# Name used for BackendConfig, FrontendConfig, and Certificate.
+# Ingress name in paths mode: <name>-ca
+# Defaults to .Release.Name if not set.
+name: ""
+
+# Optional labels applied to all resources
+labels: {}
+
+# --- Backends: one NodePort Service per entry, each with backend-config annotation ---
+backends: []
+#  - serviceName: myapp-ca
+#    port: 80
+#    targetPort: 8080
+#    serviceType: NodePort
+#    selector:
+#      app.kubernetes.io/name: myapp
+#      app.kubernetes.io/instance: myapp
+#    iap: false
+
+# --- BackendConfig (GCP; securityPolicy = Cloud Armor policy) ---
+backendConfig:
+  healthCheck:
+    requestPath: /
+    type: HTTP
+  securityPolicy:
+    name: default-ca-policy
+#  iap:
+#    enabled: false
+#    oauthclientCredentials:
+#      secretName: ""
+
+# --- FrontendConfig (HTTPS redirect, sslPolicy) ---
+frontendConfig:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: PERMANENT_REDIRECT
+#  sslPolicy: min-tls-12
+
+# --- Certificate (cert-manager) ---
+certificate:
+  host: example.trydave.com
+  secretName: ""   # default: <host>-ca-tls (dots replaced with dashes)
+  issuer: letsencrypt
+  alternativeDnsNames: []
+
+# --- Ingress ---
+ingress:
+  # staticIpName and annotations apply to the paths-mode Ingress (Option B).
+  staticIpName: ""
+  annotations: {}
+
+  # Option A: hosts — one Ingress per host; supports explicit Ingress name.
+  # Takes priority over paths when non-empty.
+  hosts: []
+  #  - host: api.example.com
+  #    name: api-example-com-ca    # explicit Ingress name (defaults to <host>-ca)
+  #    staticIpName: api-example-com-ca
+  #    annotations: {}
+  #    paths:
+  #      - backendServiceName: myapp-ca
+  #        backendPort: 80
+  #        path: /*
+  #        pathType: ImplementationSpecific
+
+  # Option B: paths — single Ingress, no host in spec.
+  paths: []
+  #  - backendServiceName: myapp-ca
+  #    backendPort: 80
+  #    path: /*
+  #    pathType: ImplementationSpecific


### PR DESCRIPTION
## Summary

- Adds standalone `cloudarmor` Helm chart (v0.2.0) for deploying GKE Cloud Armor resources independently from service charts
- Generates: `BackendConfig`, `FrontendConfig`, `Certificate` (cert-manager), `NodePort Service`, and `Ingress`
- Supports two Ingress modes: `ingress.paths` (single hostless Ingress) and `ingress.hosts` (one Ingress per host with explicit naming)

## Fixes vs prior draft

- **`ingress.yaml`**: reads `ingress.hosts` / `ingress.paths` correctly (prior version checked non-existent root-level keys and produced invalid YAML via broken `range` over backend map)
- **`service.yaml`**: `cloud.google.com/backend-config` annotation uses dynamic port from `backends[].port` (was hardcoded `80`/`443`)
- **`values.yaml`**: schema documentation now matches what templates actually read

## Test plan

- [ ] `helm template` renders all 5 resources with correct names for `ingress.paths` mode
- [ ] `helm template` renders Ingress with explicit `.name` in `ingress.hosts` mode
- [ ] Chart is published to `https://dave-inc.github.io/charts` after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)