### PR TITLE
fix: allow Twingate step to fail without blocking chart release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: Connect to Twingate
         uses: twingate/github-action@a8e6c2471f32650531a4683f45e485a2e97e048c # v1.5
+        continue-on-error: true
         with:
           service-key: ${{ secrets.TWINGATE_SERVICE_KEY}}
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the Twingate VPN step in `release.yml`
- The `Release Charts` workflow was failing on every merge because Twingate cannot connect in the CI runner, blocking `helm/chart-releaser-action` from publishing charts
- `cloudarmor v0.1.1` was never published to `https://dave-inc.github.io/charts` due to this — this fix unblocks it

## Test plan
- [ ] Merge this PR → confirm `Release Charts` CI completes and `cloudarmor v0.1.1` appears in the Helm repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)