### PR TITLE
RENT-24 - Add ability to fetch secrets from GSM before running migrations, off …

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1-beta.7
+version: 0.11.1-beta.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/workflowtemplate.yaml
+++ b/charts/common/templates/workflowtemplate.yaml
@@ -32,7 +32,7 @@ spec:
         arguments:
           parameters:
           - name: cmd
-            value: export DB_HOST={{`{{ steps.cloudsql-proxy.ip }}`}} && {{`{{workflow.parameters.command}}`}}
+            value: {{ if .Values.cloudsqlProxy.migrationTemplate.secretsFetch.enabled }}{{ concat .Values.cloudsqlProxy.migrationTemplate.secretsFetch.command .Values.cloudsqlProxy.migrationTemplate.secretsFetch.args | join " " }} && {{ end }}export DB_HOST={{`{{ steps.cloudsql-proxy.ip }}`}} && {{`{{workflow.parameters.command}}`}}
 
   - name: log-parameters
     container:

--- a/charts/common/templates/workflowtemplate.yaml
+++ b/charts/common/templates/workflowtemplate.yaml
@@ -32,7 +32,8 @@ spec:
         arguments:
           parameters:
           - name: cmd
-            value: {{ if .Values.cloudsqlProxy.migrationTemplate.secretsFetch.enabled }}{{ concat .Values.cloudsqlProxy.migrationTemplate.secretsFetch.command .Values.cloudsqlProxy.migrationTemplate.secretsFetch.args | join " " }} && {{ end }}export DB_HOST={{`{{ steps.cloudsql-proxy.ip }}`}} && {{`{{workflow.parameters.command}}`}}
+            value: |-
+              {{ if .Values.cloudsqlProxy.migrationTemplate.secretsFetch.enabled }}{{ concat .Values.cloudsqlProxy.migrationTemplate.secretsFetch.command .Values.cloudsqlProxy.migrationTemplate.secretsFetch.args | join " " }} && {{ end }}export DB_HOST={{`{{ steps.cloudsql-proxy.ip }}`}} && {{`{{workflow.parameters.command}}`}}
 
   - name: log-parameters
     container:
@@ -58,9 +59,11 @@ spec:
       image: "{{`{{workflow.parameters.image}}`}}:{{`{{workflow.parameters.tag}}`}}"
       command: [sh, -c]
       args: ["{{`{{ inputs.parameters.cmd }}`}}"]
+      {{- if not .Values.cloudsqlProxy.migrationTemplate.secretsFetch.enabled }}
       envFrom:
       - secretRef:
           name: {{ .Values.cloudsqlProxy.migrationTemplate.secretName }}
+      {{- end }}
       env:
       - name: NODE_ENV
         value: {{ .Values.environment }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -652,8 +652,8 @@ cloudsqlProxy:
       secondsAfterCompletion: 2592000 # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
       secondsAfterSuccess: 2592000 # Time to live after workflow is successful
       secondsAfterFailure: 2592000 # Time to live after workflow fails
-    # If `secretsFetch` is enabled, a step will run before the migration to fetch secrets
-    # using the same image as the migration container.
+    # If `secretsFetch` is enabled, the fetch command is prepended to the migration command
+    # and run inline in the same container (e.g. `yarn secrets:fetch && knex migrate:latest`).
     secretsFetch:
       enabled: false
       command: ["yarn"]

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -652,6 +652,12 @@ cloudsqlProxy:
       secondsAfterCompletion: 2592000 # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
       secondsAfterSuccess: 2592000 # Time to live after workflow is successful
       secondsAfterFailure: 2592000 # Time to live after workflow fails
+    # If `secretsFetch` is enabled, a step will run before the migration to fetch secrets
+    # using the same image as the migration container.
+    secretsFetch:
+      enabled: false
+      command: ["yarn"]
+      args: ["secrets:fetch"]
 
 # Generic mechanism to introduce arbitrary config files backed by a k8s ConfigMap.
 # If the file already exists on the given `path`, this will overwrite it.


### PR DESCRIPTION
**Ticket and brief summary**
In order to move away from k8 secrets, we need a call to fetch secrets before running the migration to copy the file to the pod before running knex migrations. This should be configurable since some services still use the old k8 secrets variation.

**How did you test your code?**

**How will you confirm this change is working once it's deployed?**
