### PR TITLE
[SRE-6902] `gatewayapi` chart v1.0.0

### DIFF
--- a/charts/gatewayapi/Chart.yaml
+++ b/charts/gatewayapi/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gatewayapi/schemas/gatewayapi.schema.yaml
+++ b/charts/gatewayapi/schemas/gatewayapi.schema.yaml
@@ -79,13 +79,6 @@ $defs:
                         type: integer
                     required:
                       - port
-                required:
-                  - type
-                anyOf:
-                  - required:
-                      - httpHealthCheck
-                  - required:
-                      - grpcHealthCheck
           targetRef:
             type: object
             properties:
@@ -98,8 +91,6 @@ $defs:
               name:
                 type: string
             required:
-              - group
-              - kind
               - name
         additionalProperties: false
         required:
@@ -108,6 +99,41 @@ $defs:
     required:
       - rawSpec
       - spec
+    if:
+      properties:
+        rawSpec:
+          const: true
+    then:
+      properties:
+        spec:
+          properties:
+            targetRef:
+              required:
+                - group
+                - kind
+                - name
+            default:
+              properties:
+                config:
+                  required:
+                    - type
+                  anyOf:
+                    - required:
+                        - httpHealthCheck
+                    - required:
+                        - grpcHealthCheck
+    else:
+      properties:
+        spec:
+          properties:
+            default:
+              required:
+                - config
+              properties:
+                config:
+                  required:
+                    - httpHealthCheck
+    additionalProperties: false
   route:
     type: object
     properties:
@@ -231,4 +257,5 @@ $defs:
                           required:
                             - type
                             - value
+    additionalProperties: false
 additionalProperties: false

--- a/charts/gatewayapi/schemas/gatewayapi.schema.yaml
+++ b/charts/gatewayapi/schemas/gatewayapi.schema.yaml
@@ -28,7 +28,6 @@ $defs:
     properties:
       rawSpec:
         type: boolean
-        const: true
       spec:
         type: object
         properties:

--- a/charts/gatewayapi/schemas/gatewayapi.schema.yaml
+++ b/charts/gatewayapi/schemas/gatewayapi.schema.yaml
@@ -20,6 +20,8 @@ $defs:
     properties:
       name:
         type: string
+      enabled:
+        type: boolean
       rawSpec:
         type: boolean
       spec:
@@ -144,6 +146,8 @@ $defs:
     properties:
       name:
         type: string
+      enabled:
+        type: boolean
       kind:
         type: string
         enum:

--- a/charts/gatewayapi/schemas/gatewayapi.schema.yaml
+++ b/charts/gatewayapi/schemas/gatewayapi.schema.yaml
@@ -119,7 +119,6 @@ $defs:
           - GRPCRoute
       rawSpec:
         type: boolean
-        const: true
       spec:
         type: object
         properties:
@@ -143,9 +142,6 @@ $defs:
                 namespace:
                   type: string
                   const: shared-gateways
-              required:
-                - name
-                - namespace
           rules:
             type: array
             minItems: 1
@@ -179,7 +175,6 @@ $defs:
                     required:
                       - name
                       - port
-                      - weight
                     additionalProperties: false
                 matches:
                   type: array
@@ -198,9 +193,6 @@ $defs:
                               - PathRegex
                           value:
                             type: string
-                        required:
-                          - type
-                          - value
                         additionalProperties: false
                     additionalProperties: false
         required:
@@ -211,4 +203,33 @@ $defs:
       - kind
       - rawSpec
       - spec
+    if:
+      properties:
+        rawSpec:
+          const: true
+    then:
+      properties:
+        spec:
+          properties:
+            parentRefs:
+              items:
+                required:
+                  - name
+                  - namespace
+            rules:
+              items:
+                properties:
+                  backendRefs:
+                    items:
+                      required:
+                        - name
+                        - port
+                        - weight
+                  matches:
+                    items:
+                      properties:
+                        path:
+                          required:
+                            - type
+                            - value
 additionalProperties: false

--- a/charts/gatewayapi/schemas/gatewayapi.schema.yaml
+++ b/charts/gatewayapi/schemas/gatewayapi.schema.yaml
@@ -61,18 +61,26 @@ $defs:
                     properties:
                       port:
                         type: integer
+                        minimum: 1
+                        maximum: 65535
                       requestPath:
                         type: string
                     required:
                       - port
                       - requestPath
+                    additionalProperties: false
                   grpcHealthCheck:
                     type: object
                     properties:
                       port:
                         type: integer
+                        minimum: 1
+                        maximum: 65535
                     required:
                       - port
+                    additionalProperties: false
+                additionalProperties: false
+            additionalProperties: false
           targetRef:
             type: object
             properties:
@@ -86,6 +94,7 @@ $defs:
                 type: string
             required:
               - name
+            additionalProperties: false
         additionalProperties: false
         required:
           - default
@@ -159,12 +168,19 @@ $defs:
             items:
               type: object
               properties:
+                group:
+                  type: string
+                  const: "gateway.networking.k8s.io"
+                kind:
+                  type: string
+                  const: Gateway
                 name:
                   type: string
                   pattern: "^shared-gw-\\d+$"
                 namespace:
                   type: string
                   const: shared-gateways
+              additionalProperties: false
           rules:
             type: array
             minItems: 1
@@ -184,6 +200,8 @@ $defs:
                         type: string
                       port:
                         type: integer
+                        minimum: 1
+                        maximum: 65535
                       weight:
                         type: integer
                         # For the time being, we only support a single backend ref per rule,
@@ -218,9 +236,11 @@ $defs:
                             type: string
                         additionalProperties: false
                     additionalProperties: false
+              additionalProperties: false
         required:
           - hostnames
           - rules
+        additionalProperties: false
     required:
       - name
       - spec
@@ -233,6 +253,8 @@ $defs:
     then:
       properties:
         spec:
+          required:
+            - parentRefs
           properties:
             parentRefs:
               items:

--- a/charts/gatewayapi/schemas/gatewayapi.schema.yaml
+++ b/charts/gatewayapi/schemas/gatewayapi.schema.yaml
@@ -5,27 +5,21 @@ properties:
   gateways:
     type: object
   routes:
-    type: object
-    properties:
-      main:
-        $ref: "#/$defs/route"
-    additionalProperties:
+    type: array
+    minItems: 1
+    items:
       $ref: "#/$defs/route"
-    required:
-      - main
   healthCheckPolicies:
-    type: object
-    properties:
-      main:
-        $ref: "#/$defs/healthCheckPolicy"
-    additionalProperties:
+    type: array
+    minItems: 1
+    items:
       $ref: "#/$defs/healthCheckPolicy"
-    required:
-      - main
 $defs:
   healthCheckPolicy:
     type: object
     properties:
+      name:
+        type: string
       rawSpec:
         type: boolean
       spec:
@@ -97,9 +91,11 @@ $defs:
           - default
           - targetRef
     required:
-      - rawSpec
+      - name
       - spec
     if:
+      required:
+        - rawSpec
       properties:
         rawSpec:
           const: true
@@ -137,6 +133,8 @@ $defs:
   route:
     type: object
     properties:
+      name:
+        type: string
       kind:
         type: string
         enum:
@@ -222,13 +220,13 @@ $defs:
                     additionalProperties: false
         required:
           - hostnames
-          - parentRefs
           - rules
     required:
-      - kind
-      - rawSpec
+      - name
       - spec
     if:
+      required:
+        - rawSpec
       properties:
         rawSpec:
           const: true

--- a/charts/gatewayapi/templates/healthcheckpolicy.yaml
+++ b/charts/gatewayapi/templates/healthcheckpolicy.yaml
@@ -1,17 +1,17 @@
 {{- if .Values.enabled }}
 {{- $labels := include "gatewayapi.labels" . }}
 {{- $commonName := include "gatewayapi.name" . }}
-{{- range $healthCheckPolicyName, $healthCheckPolicyDefinition := .Values.healthCheckPolicies }}
+{{- range $healthCheckPolicyDefinition := .Values.healthCheckPolicies }}
 ---
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:
   labels:
     {{- $labels | nindent 4 }}
-  name: {{ $commonName }}-{{ $healthCheckPolicyName }}
+  name: {{ $commonName }}-{{ $healthCheckPolicyDefinition.name }}
 spec:
 {{- if and $healthCheckPolicyDefinition.spec $healthCheckPolicyDefinition.rawSpec }}
-  {{- toYaml $healthCheckPolicyDefinition.spec | indent 2 }}
+  {{- toYaml $healthCheckPolicyDefinition.spec | nindent 2 }}
 {{- else }}
   default:
     config:
@@ -20,13 +20,13 @@ spec:
         requestPath: {{ $healthCheckPolicyDefinition.spec.default.config.httpHealthCheck.requestPath }}
       type: {{ $healthCheckPolicyDefinition.spec.default.config.type | default "HTTP" }}
     logConfig:
-      enabled: {{ $healthCheckPolicyDefinition.spec.default.logConfig.enabled | default true }}
-    checkIntervalSec: {{ $healthCheckPolicyDefinition.spec.default.checkIntervalSec | default 30 }}
-    timeouteSec: {{ $healthCheckPolicyDefinition.spec.default.timeoutSec | default 10 }}
-    healthThreshold: {{ $healthCheckPolicyDefinition.spec.default.healthThreshold | default 1 }}
+      enabled: {{ dig "logConfig" "enabled" true $healthCheckPolicyDefinition.spec.default }}
+    checkIntervalSec: {{ $healthCheckPolicyDefinition.spec.default.checkIntervalSec | default 10 }}
+    timeoutSec: {{ $healthCheckPolicyDefinition.spec.default.timeoutSec | default 1 }}
+    healthyThreshold: {{ $healthCheckPolicyDefinition.spec.default.healthyThreshold | default 1 }}
     unhealthyThreshold: {{ $healthCheckPolicyDefinition.spec.default.unhealthyThreshold | default 3 }}
   targetRef:
-    group: {{ $healthCheckPolicyDefinition.spec.targetRef.group | default "" }}
+    group: {{ $healthCheckPolicyDefinition.spec.targetRef.group | default "" | quote }}
     kind: {{ $healthCheckPolicyDefinition.spec.targetRef.kind | default "Service" }}
     name: {{ $healthCheckPolicyDefinition.spec.targetRef.name }}
 {{- end }}

--- a/charts/gatewayapi/templates/healthcheckpolicy.yaml
+++ b/charts/gatewayapi/templates/healthcheckpolicy.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.enabled }}
+{{- $seen := dict }}
+{{- range $healthCheckPolicyDefinition := .Values.healthCheckPolicies }}
+{{- if hasKey $seen $healthCheckPolicyDefinition.name }}
+{{- fail (printf "HealthCheckPolicy names must be unique: '%s' is duplicated" $healthCheckPolicyDefinition.name) }}
+{{- end }}
+{{- $_ := set $seen $healthCheckPolicyDefinition.name true }}
+{{- end }}
 {{- $labels := include "gatewayapi.labels" . }}
 {{- $commonName := include "gatewayapi.name" . }}
 {{- range $healthCheckPolicyDefinition := .Values.healthCheckPolicies }}

--- a/charts/gatewayapi/templates/healthcheckpolicy.yaml
+++ b/charts/gatewayapi/templates/healthcheckpolicy.yaml
@@ -9,6 +9,7 @@
 {{- $labels := include "gatewayapi.labels" . }}
 {{- $commonName := include "gatewayapi.name" . }}
 {{- range $healthCheckPolicyDefinition := .Values.healthCheckPolicies }}
+{{- if (ne $healthCheckPolicyDefinition.enabled false) }}
 ---
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
@@ -36,6 +37,7 @@ spec:
     group: {{ $healthCheckPolicyDefinition.spec.targetRef.group | default "" | quote }}
     kind: {{ $healthCheckPolicyDefinition.spec.targetRef.kind | default "Service" }}
     name: {{ $healthCheckPolicyDefinition.spec.targetRef.name }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gatewayapi/templates/healthcheckpolicy.yaml
+++ b/charts/gatewayapi/templates/healthcheckpolicy.yaml
@@ -11,7 +11,24 @@ metadata:
   name: {{ $commonName }}-{{ $healthCheckPolicyName }}
 spec:
 {{- if and $healthCheckPolicyDefinition.spec $healthCheckPolicyDefinition.rawSpec }}
-{{ toYaml $healthCheckPolicyDefinition.spec | indent 2 }}
+  {{- toYaml $healthCheckPolicyDefinition.spec | indent 2 }}
+{{- else }}
+  default:
+    config:
+      httpHealthCheck:
+        port: {{ $healthCheckPolicyDefinition.spec.default.config.httpHealthCheck.port }}
+        requestPath: {{ $healthCheckPolicyDefinition.spec.default.config.httpHealthCheck.requestPath }}
+      type: {{ $healthCheckPolicyDefinition.spec.default.config.type | default "HTTP" }}
+    logConfig:
+      enabled: {{ $healthCheckPolicyDefinition.spec.default.logConfig.enabled | default true }}
+    checkIntervalSec: {{ $healthCheckPolicyDefinition.spec.default.checkIntervalSec | default 30 }}
+    timeouteSec: {{ $healthCheckPolicyDefinition.spec.default.timeoutSec | default 10 }}
+    healthThreshold: {{ $healthCheckPolicyDefinition.spec.default.healthThreshold | default 1 }}
+    unhealthyThreshold: {{ $healthCheckPolicyDefinition.spec.default.unhealthyThreshold | default 3 }}
+  targetRef:
+    group: {{ $healthCheckPolicyDefinition.spec.targetRef.group | default "" }}
+    kind: {{ $healthCheckPolicyDefinition.spec.targetRef.kind | default "Service" }}
+    name: {{ $healthCheckPolicyDefinition.spec.targetRef.name }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gatewayapi/templates/healthcheckpolicy.yaml
+++ b/charts/gatewayapi/templates/healthcheckpolicy.yaml
@@ -28,10 +28,10 @@ spec:
       type: {{ $healthCheckPolicyDefinition.spec.default.config.type | default "HTTP" }}
     logConfig:
       enabled: {{ dig "logConfig" "enabled" true $healthCheckPolicyDefinition.spec.default }}
-    checkIntervalSec: {{ $healthCheckPolicyDefinition.spec.default.checkIntervalSec | default 10 }}
+    checkIntervalSec: {{ $healthCheckPolicyDefinition.spec.default.checkIntervalSec | default 5 }}
     timeoutSec: {{ $healthCheckPolicyDefinition.spec.default.timeoutSec | default 1 }}
-    healthyThreshold: {{ $healthCheckPolicyDefinition.spec.default.healthyThreshold | default 1 }}
-    unhealthyThreshold: {{ $healthCheckPolicyDefinition.spec.default.unhealthyThreshold | default 3 }}
+    healthyThreshold: {{ $healthCheckPolicyDefinition.spec.default.healthyThreshold | default 2 }}
+    unhealthyThreshold: {{ $healthCheckPolicyDefinition.spec.default.unhealthyThreshold | default 2 }}
   targetRef:
     group: {{ $healthCheckPolicyDefinition.spec.targetRef.group | default "" | quote }}
     kind: {{ $healthCheckPolicyDefinition.spec.targetRef.kind | default "Service" }}

--- a/charts/gatewayapi/templates/httproute.yaml
+++ b/charts/gatewayapi/templates/httproute.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.enabled }}
+{{- $seen := dict }}
+{{- range $routeDefinition := .Values.routes }}
+{{- if hasKey $seen $routeDefinition.name }}
+{{- fail (printf "Route names must be unique: '%s' is duplicated" $routeDefinition.name) }}
+{{- end }}
+{{- $_ := set $seen $routeDefinition.name true }}
+{{- end }}
 {{- $labels := include "gatewayapi.labels" . }}
 {{- $commonName := include "gatewayapi.name" . }}
 {{- range $routeDefinition := .Values.routes }}

--- a/charts/gatewayapi/templates/httproute.yaml
+++ b/charts/gatewayapi/templates/httproute.yaml
@@ -9,7 +9,7 @@
 {{- $labels := include "gatewayapi.labels" . }}
 {{- $commonName := include "gatewayapi.name" . }}
 {{- range $routeDefinition := .Values.routes }}
-{{- if eq (default "HTTPRoute" $routeDefinition.kind) "HTTPRoute" }}
+{{- if (and (ne $routeDefinition.enabled false) (eq (default "HTTPRoute" $routeDefinition.kind) "HTTPRoute")) }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/gatewayapi/templates/httproute.yaml
+++ b/charts/gatewayapi/templates/httproute.yaml
@@ -11,8 +11,39 @@ metadata:
     {{- $labels | nindent 4 }}
   name: {{ $commonName }}-{{ $routeName }}
 spec:
-{{- if and $routeDefinition.spec $routeDefinition.rawSpec }}
-{{ toYaml $routeDefinition.spec | indent 2 }}
+{{- if (and $routeDefinition.spec $routeDefinition.rawSpec) }}
+  {{- toYaml $routeDefinition.spec | nindent 2 -}}
+{{- else }}
+  hostnames:
+    {{- range $routeDefinition.spec.hostnames }}
+    - {{ . }}
+    {{- end }}
+  parentRefs:
+    {{- range $routeDefinition.spec.parentRefs }}
+  - group: {{ .group | default "gateway.networking.k8s.io" }}
+    kind: {{ .kind | default "Gateway" }}
+    name: {{ .name | default "shared-gw-0" }}
+    namespace: {{ .namespace | default "shared-gateways" }}
+    {{- end }}
+  rules:
+    {{- range $routeDefinition.spec.rules }}
+    - backendRefs:
+        {{- range .backendRefs }}
+      - group: {{ .group | default "" }}
+        kind: {{ .kind | default "Service" }}
+        name: {{ .name }}
+        port: {{ .port }}
+        weight: {{ .weight | default 1 }}
+        {{- end }}
+      {{- if .matches }}
+      matches:
+        {{- range .matches }}
+        - path:
+            type: {{ .path.type | default "PathPrefix" }}
+            value: {{ .path.value | default "/" }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gatewayapi/templates/httproute.yaml
+++ b/charts/gatewayapi/templates/httproute.yaml
@@ -1,15 +1,15 @@
 {{- if .Values.enabled }}
 {{- $labels := include "gatewayapi.labels" . }}
 {{- $commonName := include "gatewayapi.name" . }}
-{{- range $routeName, $routeDefinition := .Values.routes }}
-{{- if eq $routeDefinition.kind "HTTPRoute" }}
+{{- range $routeDefinition := .Values.routes }}
+{{- if eq (default "HTTPRoute" $routeDefinition.kind) "HTTPRoute" }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   labels:
     {{- $labels | nindent 4 }}
-  name: {{ $commonName }}-{{ $routeName }}
+  name: {{ $commonName }}-{{ $routeDefinition.name }}
 spec:
 {{- if (and $routeDefinition.spec $routeDefinition.rawSpec) }}
   {{- toYaml $routeDefinition.spec | nindent 2 -}}
@@ -19,30 +19,41 @@ spec:
     - {{ . }}
     {{- end }}
   parentRefs:
+  {{- if $routeDefinition.spec.parentRefs }}
     {{- range $routeDefinition.spec.parentRefs }}
   - group: {{ .group | default "gateway.networking.k8s.io" }}
     kind: {{ .kind | default "Gateway" }}
     name: {{ .name | default "shared-gw-0" }}
     namespace: {{ .namespace | default "shared-gateways" }}
     {{- end }}
+  {{- else }}
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: shared-gw-0
+    namespace: shared-gateways
+  {{- end }}
   rules:
     {{- range $routeDefinition.spec.rules }}
     - backendRefs:
         {{- range .backendRefs }}
-      - group: {{ .group | default "" }}
+      - group: {{ .group | default "" | quote }}
         kind: {{ .kind | default "Service" }}
         name: {{ .name }}
         port: {{ .port }}
         weight: {{ .weight | default 1 }}
         {{- end }}
-      {{- if .matches }}
       matches:
+        {{- if .matches }}
         {{- range .matches }}
         - path:
             type: {{ .path.type | default "PathPrefix" }}
             value: {{ .path.value | default "/" }}
         {{- end }}
-      {{- end }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gatewayapi/values.schema.json
+++ b/charts/gatewayapi/values.schema.json
@@ -54,6 +54,14 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "group": {
+                      "type": "string",
+                      "const": "gateway.networking.k8s.io"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "const": "Gateway"
+                    },
                     "name": {
                       "type": "string",
                       "pattern": "^shared-gw-\\d+$"
@@ -62,7 +70,8 @@
                       "type": "string",
                       "const": "shared-gateways"
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 }
               },
               "rules": {
@@ -82,7 +91,9 @@
                             "type": "string"
                           },
                           "port": {
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
                           },
                           "weight": {
                             "type": "integer",
@@ -131,14 +142,16 @@
                         "additionalProperties": false
                       }
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 }
               }
             },
             "required": [
               "hostnames",
               "rules"
-            ]
+            ],
+            "additionalProperties": false
           }
         },
         "required": [
@@ -158,6 +171,9 @@
         "then": {
           "properties": {
             "spec": {
+              "required": [
+                "parentRefs"
+              ],
               "properties": {
                 "parentRefs": {
                   "items": {
@@ -261,7 +277,9 @@
                         "type": "object",
                         "properties": {
                           "port": {
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
                           },
                           "requestPath": {
                             "type": "string"
@@ -270,22 +288,28 @@
                         "required": [
                           "port",
                           "requestPath"
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "grpcHealthCheck": {
                         "type": "object",
                         "properties": {
                           "port": {
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
                           }
                         },
                         "required": [
                           "port"
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   }
-                }
+                },
+                "additionalProperties": false
               },
               "targetRef": {
                 "type": "object",
@@ -304,7 +328,8 @@
                 },
                 "required": [
                   "name"
-                ]
+                ],
+                "additionalProperties": false
               }
             },
             "additionalProperties": false,

--- a/charts/gatewayapi/values.schema.json
+++ b/charts/gatewayapi/values.schema.json
@@ -193,7 +193,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": {
@@ -369,7 +370,8 @@
               }
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "required": [
         "main"
@@ -454,22 +456,7 @@
                             "port"
                           ]
                         }
-                      },
-                      "required": [
-                        "type"
-                      ],
-                      "anyOf": [
-                        {
-                          "required": [
-                            "httpHealthCheck"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "grpcHealthCheck"
-                          ]
-                        }
-                      ]
+                      }
                     }
                   }
                 },
@@ -489,8 +476,6 @@
                     }
                   },
                   "required": [
-                    "group",
-                    "kind",
                     "name"
                   ]
                 }
@@ -505,7 +490,71 @@
           "required": [
             "rawSpec",
             "spec"
-          ]
+          ],
+          "if": {
+            "properties": {
+              "rawSpec": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "spec": {
+                "properties": {
+                  "targetRef": {
+                    "required": [
+                      "group",
+                      "kind",
+                      "name"
+                    ]
+                  },
+                  "default": {
+                    "properties": {
+                      "config": {
+                        "required": [
+                          "type"
+                        ],
+                        "anyOf": [
+                          {
+                            "required": [
+                              "httpHealthCheck"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "grpcHealthCheck"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "spec": {
+                "properties": {
+                  "default": {
+                    "required": [
+                      "config"
+                    ],
+                    "properties": {
+                      "config": {
+                        "required": [
+                          "httpHealthCheck"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": {
@@ -584,22 +633,7 @@
                           "port"
                         ]
                       }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "anyOf": [
-                      {
-                        "required": [
-                          "httpHealthCheck"
-                        ]
-                      },
-                      {
-                        "required": [
-                          "grpcHealthCheck"
-                        ]
-                      }
-                    ]
+                    }
                   }
                 }
               },
@@ -619,8 +653,6 @@
                   }
                 },
                 "required": [
-                  "group",
-                  "kind",
                   "name"
                 ]
               }
@@ -635,7 +667,71 @@
         "required": [
           "rawSpec",
           "spec"
-        ]
+        ],
+        "if": {
+          "properties": {
+            "rawSpec": {
+              "const": true
+            }
+          }
+        },
+        "then": {
+          "properties": {
+            "spec": {
+              "properties": {
+                "targetRef": {
+                  "required": [
+                    "group",
+                    "kind",
+                    "name"
+                  ]
+                },
+                "default": {
+                  "properties": {
+                    "config": {
+                      "required": [
+                        "type"
+                      ],
+                      "anyOf": [
+                        {
+                          "required": [
+                            "httpHealthCheck"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "grpcHealthCheck"
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "else": {
+          "properties": {
+            "spec": {
+              "properties": {
+                "default": {
+                  "required": [
+                    "config"
+                  ],
+                  "properties": {
+                    "config": {
+                      "required": [
+                        "httpHealthCheck"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "required": [
         "main"

--- a/charts/gatewayapi/values.schema.json
+++ b/charts/gatewayapi/values.schema.json
@@ -382,8 +382,7 @@
           "type": "object",
           "properties": {
             "rawSpec": {
-              "type": "boolean",
-              "const": true
+              "type": "boolean"
             },
             "spec": {
               "type": "object",
@@ -513,8 +512,7 @@
         "type": "object",
         "properties": {
           "rawSpec": {
-            "type": "boolean",
-            "const": true
+            "type": "boolean"
           },
           "spec": {
             "type": "object",

--- a/charts/gatewayapi/values.schema.json
+++ b/charts/gatewayapi/values.schema.json
@@ -18,188 +18,14 @@
       "type": "object"
     },
     "routes": {
-      "type": "object",
-      "properties": {
-        "main": {
-          "type": "object",
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "GRPCRoute"
-              ]
-            },
-            "rawSpec": {
-              "type": "boolean"
-            },
-            "spec": {
-              "type": "object",
-              "properties": {
-                "hostnames": {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "type": "string",
-                    "pattern": "^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\\.)*(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
-                  }
-                },
-                "parentRefs": {
-                  "type": "array",
-                  "minItems": 1,
-                  "maxItems": 1,
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "pattern": "^shared-gw-\\d+$"
-                      },
-                      "namespace": {
-                        "type": "string",
-                        "const": "shared-gateways"
-                      }
-                    }
-                  }
-                },
-                "rules": {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "backendRefs": {
-                        "type": "array",
-                        "minItems": 1,
-                        "maxItems": 1,
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "type": "integer"
-                            },
-                            "weight": {
-                              "type": "integer",
-                              "const": 1
-                            },
-                            "group": {
-                              "type": "string",
-                              "const": ""
-                            },
-                            "kind": {
-                              "type": "string",
-                              "const": "Service"
-                            }
-                          },
-                          "required": [
-                            "name",
-                            "port"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "matches": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "path": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "enum": [
-                                    "PathPrefix",
-                                    "PathExact",
-                                    "PathRegex"
-                                  ]
-                                },
-                                "value": {
-                                  "type": "string"
-                                }
-                              },
-                              "additionalProperties": false
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "required": [
-                "hostnames",
-                "parentRefs",
-                "rules"
-              ]
-            }
-          },
-          "required": [
-            "kind",
-            "rawSpec",
-            "spec"
-          ],
-          "if": {
-            "properties": {
-              "rawSpec": {
-                "const": true
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "spec": {
-                "properties": {
-                  "parentRefs": {
-                    "items": {
-                      "required": [
-                        "name",
-                        "namespace"
-                      ]
-                    }
-                  },
-                  "rules": {
-                    "items": {
-                      "properties": {
-                        "backendRefs": {
-                          "items": {
-                            "required": [
-                              "name",
-                              "port",
-                              "weight"
-                            ]
-                          }
-                        },
-                        "matches": {
-                          "items": {
-                            "properties": {
-                              "path": {
-                                "required": [
-                                  "type",
-                                  "value"
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "kind": {
             "type": "string",
             "enum": [
@@ -311,17 +137,18 @@
             },
             "required": [
               "hostnames",
-              "parentRefs",
               "rules"
             ]
           }
         },
         "required": [
-          "kind",
-          "rawSpec",
+          "name",
           "spec"
         ],
         "if": {
+          "required": [
+            "rawSpec"
+          ],
           "properties": {
             "rawSpec": {
               "const": true
@@ -372,194 +199,17 @@
           }
         },
         "additionalProperties": false
-      },
-      "required": [
-        "main"
-      ]
+      }
     },
     "healthCheckPolicies": {
-      "type": "object",
-      "properties": {
-        "main": {
-          "type": "object",
-          "properties": {
-            "rawSpec": {
-              "type": "boolean"
-            },
-            "spec": {
-              "type": "object",
-              "properties": {
-                "default": {
-                  "type": "object",
-                  "properties": {
-                    "checkIntervalSec": {
-                      "type": "integer",
-                      "minimum": 1
-                    },
-                    "timeoutSec": {
-                      "type": "integer",
-                      "minimum": 1
-                    },
-                    "healthyThreshold": {
-                      "type": "integer",
-                      "minimum": 1
-                    },
-                    "unhealthyThreshold": {
-                      "type": "integer",
-                      "minimum": 1
-                    },
-                    "logConfig": {
-                      "type": "object",
-                      "properties": {
-                        "enabled": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "enabled"
-                      ],
-                      "additionalProperties": false
-                    },
-                    "config": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "HTTP",
-                            "GRPC"
-                          ]
-                        },
-                        "httpHealthCheck": {
-                          "type": "object",
-                          "properties": {
-                            "port": {
-                              "type": "integer"
-                            },
-                            "requestPath": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "port",
-                            "requestPath"
-                          ]
-                        },
-                        "grpcHealthCheck": {
-                          "type": "object",
-                          "properties": {
-                            "port": {
-                              "type": "integer"
-                            }
-                          },
-                          "required": [
-                            "port"
-                          ]
-                        }
-                      }
-                    }
-                  }
-                },
-                "targetRef": {
-                  "type": "object",
-                  "properties": {
-                    "group": {
-                      "type": "string",
-                      "const": ""
-                    },
-                    "kind": {
-                      "type": "string",
-                      "const": "Service"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "default",
-                "targetRef"
-              ]
-            }
-          },
-          "required": [
-            "rawSpec",
-            "spec"
-          ],
-          "if": {
-            "properties": {
-              "rawSpec": {
-                "const": true
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "spec": {
-                "properties": {
-                  "targetRef": {
-                    "required": [
-                      "group",
-                      "kind",
-                      "name"
-                    ]
-                  },
-                  "default": {
-                    "properties": {
-                      "config": {
-                        "required": [
-                          "type"
-                        ],
-                        "anyOf": [
-                          {
-                            "required": [
-                              "httpHealthCheck"
-                            ]
-                          },
-                          {
-                            "required": [
-                              "grpcHealthCheck"
-                            ]
-                          }
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "else": {
-            "properties": {
-              "spec": {
-                "properties": {
-                  "default": {
-                    "required": [
-                      "config"
-                    ],
-                    "properties": {
-                      "config": {
-                        "required": [
-                          "httpHealthCheck"
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "rawSpec": {
             "type": "boolean"
           },
@@ -665,10 +315,13 @@
           }
         },
         "required": [
-          "rawSpec",
+          "name",
           "spec"
         ],
         "if": {
+          "required": [
+            "rawSpec"
+          ],
           "properties": {
             "rawSpec": {
               "const": true
@@ -732,10 +385,7 @@
           }
         },
         "additionalProperties": false
-      },
-      "required": [
-        "main"
-      ]
+      }
     }
   }
 }

--- a/charts/gatewayapi/values.schema.json
+++ b/charts/gatewayapi/values.schema.json
@@ -31,8 +31,7 @@
               ]
             },
             "rawSpec": {
-              "type": "boolean",
-              "const": true
+              "type": "boolean"
             },
             "spec": {
               "type": "object",
@@ -60,11 +59,7 @@
                         "type": "string",
                         "const": "shared-gateways"
                       }
-                    },
-                    "required": [
-                      "name",
-                      "namespace"
-                    ]
+                    }
                   }
                 },
                 "rules": {
@@ -101,8 +96,7 @@
                           },
                           "required": [
                             "name",
-                            "port",
-                            "weight"
+                            "port"
                           ],
                           "additionalProperties": false
                         }
@@ -128,10 +122,6 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
                               "additionalProperties": false
                             }
                           },
@@ -153,7 +143,57 @@
             "kind",
             "rawSpec",
             "spec"
-          ]
+          ],
+          "if": {
+            "properties": {
+              "rawSpec": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "spec": {
+                "properties": {
+                  "parentRefs": {
+                    "items": {
+                      "required": [
+                        "name",
+                        "namespace"
+                      ]
+                    }
+                  },
+                  "rules": {
+                    "items": {
+                      "properties": {
+                        "backendRefs": {
+                          "items": {
+                            "required": [
+                              "name",
+                              "port",
+                              "weight"
+                            ]
+                          }
+                        },
+                        "matches": {
+                          "items": {
+                            "properties": {
+                              "path": {
+                                "required": [
+                                  "type",
+                                  "value"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "additionalProperties": {
@@ -167,8 +207,7 @@
             ]
           },
           "rawSpec": {
-            "type": "boolean",
-            "const": true
+            "type": "boolean"
           },
           "spec": {
             "type": "object",
@@ -196,11 +235,7 @@
                       "type": "string",
                       "const": "shared-gateways"
                     }
-                  },
-                  "required": [
-                    "name",
-                    "namespace"
-                  ]
+                  }
                 }
               },
               "rules": {
@@ -237,8 +272,7 @@
                         },
                         "required": [
                           "name",
-                          "port",
-                          "weight"
+                          "port"
                         ],
                         "additionalProperties": false
                       }
@@ -264,10 +298,6 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type",
-                              "value"
-                            ],
                             "additionalProperties": false
                           }
                         },
@@ -289,7 +319,57 @@
           "kind",
           "rawSpec",
           "spec"
-        ]
+        ],
+        "if": {
+          "properties": {
+            "rawSpec": {
+              "const": true
+            }
+          }
+        },
+        "then": {
+          "properties": {
+            "spec": {
+              "properties": {
+                "parentRefs": {
+                  "items": {
+                    "required": [
+                      "name",
+                      "namespace"
+                    ]
+                  }
+                },
+                "rules": {
+                  "items": {
+                    "properties": {
+                      "backendRefs": {
+                        "items": {
+                          "required": [
+                            "name",
+                            "port",
+                            "weight"
+                          ]
+                        }
+                      },
+                      "matches": {
+                        "items": {
+                          "properties": {
+                            "path": {
+                              "required": [
+                                "type",
+                                "value"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       },
       "required": [
         "main"

--- a/charts/gatewayapi/values.schema.json
+++ b/charts/gatewayapi/values.schema.json
@@ -26,6 +26,9 @@
           "name": {
             "type": "string"
           },
+          "enabled": {
+            "type": "boolean"
+          },
           "kind": {
             "type": "string",
             "enum": [
@@ -225,6 +228,9 @@
         "properties": {
           "name": {
             "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
           },
           "rawSpec": {
             "type": "boolean"

--- a/charts/gatewayapi/values.yaml
+++ b/charts/gatewayapi/values.yaml
@@ -27,6 +27,8 @@ gateways:
 # resource (e.g. `<release>-<name>`). Names must be unique across items.
 healthCheckPolicies:
   - name: main
+    # If true, the policy will be rendered. If false, it will be omitted.
+    enabled: true
     rawSpec: true
     spec:
       default:
@@ -52,6 +54,8 @@ healthCheckPolicies:
 # declare its `kind` (HTTPRoute or GRPCRoute) and a `spec` block.
 routes:
   - name: main
+    # If true, the route will be rendered. If false, it will be omitted.
+    enabled: true
     # GRPCRoute being another option
     kind: HTTPRoute
     # If set to true, no defaults will be used and the spec block will be

--- a/charts/gatewayapi/values.yaml
+++ b/charts/gatewayapi/values.yaml
@@ -29,7 +29,7 @@ gateways:
 # networking.gke.io/v1 HealthCheckPolicy.
 healthCheckPolicies:
   main:
-    rawSpec: true
+    rawSpec: false
     spec:
       default:
         checkIntervalSec: 10

--- a/charts/gatewayapi/values.yaml
+++ b/charts/gatewayapi/values.yaml
@@ -23,13 +23,11 @@ gateways:
         # Overrides defaultNamespace for this reference
         namespace: shared-gateways
 
-# HealthCheckPolicies map. Each key becomes the suffix of the rendered resource
-# (e.g. `<release>-<key>`). Each entry must have `rawSpec: true` and a `spec`
-# block whose contents are passed through verbatim to a
-# networking.gke.io/v1 HealthCheckPolicy.
+# HealthCheckPolicies list. Each item's `name` becomes the suffix of the rendered
+# resource (e.g. `<release>-<name>`). Names must be unique across items.
 healthCheckPolicies:
-  main:
-    rawSpec: false
+  - name: main
+    rawSpec: true
     spec:
       default:
         checkIntervalSec: 10
@@ -49,12 +47,11 @@ healthCheckPolicies:
         kind: Service
         name: example-service
 
-# Routes map. Each key becomes the suffix of the rendered route resource
-# (e.g. `<release>-<key>`). Each entry must declare its `kind` (HTTPRoute or
-# GRPCRoute), `rawSpec: true`, and a `spec` block passed through verbatim to
-# the rendered resource.
+# Routes list. Each item's `name` becomes the suffix of the rendered route resource
+# (e.g. `<release>-<name>`). Names must be unique across items. Each entry must
+# declare its `kind` (HTTPRoute or GRPCRoute) and a `spec` block.
 routes:
-  main:
+  - name: main
     # GRPCRoute being another option
     kind: HTTPRoute
     # If set to true, no defaults will be used and the spec block will be
@@ -62,7 +59,7 @@ routes:
     #
     # If false, the spec block will be merged with some defaults
     # (e.g. parentRefs) that can be overridden by the user.
-    rawSpec: false
+    rawSpec: true
     spec:
       hostnames:
         - example-service.daveapi.io

--- a/charts/gatewayapi/values.yaml
+++ b/charts/gatewayapi/values.yaml
@@ -55,8 +55,14 @@ healthCheckPolicies:
 # the rendered resource.
 routes:
   main:
-    kind: HTTPRoute # GRPCRoute being another option
-    rawSpec: true
+    # GRPCRoute being another option
+    kind: HTTPRoute
+    # If set to true, no defaults will be used and the spec block will be
+    # passed through verbatim.
+    #
+    # If false, the spec block will be merged with some defaults
+    # (e.g. parentRefs) that can be overridden by the user.
+    rawSpec: false
     spec:
       hostnames:
         - example-service.daveapi.io


### PR DESCRIPTION
**Ticket**
[SRE-6902](https://demoforthedaves.atlassian.net/browse/SRE-6902)

**Ticket and brief summary**
- Bump chart version
- Introduce `enabled` fields for both HTTPRoute and HealthCheckPolicy resources
- Preview
- Validate for name uniqueness
- Change the format of `routes` and `healthCheckPolicies` entries from map of objects to list of objects.
- Update json schema for the changes introduced in the previous commit
- Introduce some defaults to the HealthCheckPolicy resource when rawSpec is set to false
- Update json schema for the changes introduced in the previous commit
- Introduce some defaults to the HTTPRoute resource when rawSpec is set to false

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[SRE-6902]: https://demoforthedaves.atlassian.net/browse/SRE-6902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ