### PR TITLE
[SRE-6902] `gatewayapi` chart v2.2.0

### DIFF
--- a/charts/gatewayapi/Chart.yaml
+++ b/charts/gatewayapi/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gatewayapi/README.md
+++ b/charts/gatewayapi/README.md
@@ -17,6 +17,8 @@ routes:
       spec:
         hostnames:
           - example-service.trydave.com
+        parentRefs:
+          - name: default
         rules:
           - backendRefs:
               - name: example-service

--- a/charts/gatewayapi/README.md
+++ b/charts/gatewayapi/README.md
@@ -41,7 +41,7 @@ healthCheckPolicies:
 Most of the time, that will be all you need to do. The defaults in place take
 care of the most common use cases.
 
-Resources are named using the pattern `{Release.Name}-{item.name}`.
+Resources are named using the `name` field from each item (e.g. `example-service`).
 
 Just for illustration purposes, here is how the same configuration would
 look like if we were to use `ingress` instead of `gatewayapi`:

--- a/charts/gatewayapi/examples/custom-path-match.yaml
+++ b/charts/gatewayapi/examples/custom-path-match.yaml
@@ -8,6 +8,8 @@ routes:
       spec:
         hostnames:
           - example-service.trydave.com
+        parentRefs:
+          - name: default
         rules:
           - backendRefs:
               - name: example-service

--- a/charts/gatewayapi/examples/redirect.yaml
+++ b/charts/gatewayapi/examples/redirect.yaml
@@ -8,6 +8,8 @@ routes:
       spec:
         hostnames:
           - redirect-me.trydave.com
+        parentRefs:
+          - name: default
         rules:
           - filters:
               - type: RequestRedirect

--- a/charts/gatewayapi/examples/simple.yaml
+++ b/charts/gatewayapi/examples/simple.yaml
@@ -1,7 +1,7 @@
 # Minimal Gateway API deployment: routes traffic for
 # `example-service.trydave.com` to the `example-service` Service on port 80,
 # with an HTTP health check on pod port 8080. Relies on chart defaults for
-# parentRefs, path match, and health check intervals/thresholds.
+# path match and health check intervals/thresholds.
 enabled: true
 routes:
   items:
@@ -9,6 +9,8 @@ routes:
       spec:
         hostnames:
           - example-service.trydave.com
+        parentRefs:
+          - name: default
         rules:
           - backendRefs:
               - name: example-service

--- a/charts/gatewayapi/examples/timeouts.yaml
+++ b/charts/gatewayapi/examples/timeouts.yaml
@@ -9,6 +9,8 @@ routes:
       spec:
         hostnames:
           - example-service.trydave.com
+        parentRefs:
+          - name: default
         rules:
           - backendRefs:
               - name: example-service

--- a/charts/gatewayapi/schemas/gatewayapi.schema.yaml
+++ b/charts/gatewayapi/schemas/gatewayapi.schema.yaml
@@ -357,6 +357,16 @@ $defs:
                       then:
                         required:
                           - requestRedirect
+    else:
+      properties:
+        spec:
+          required:
+            - parentRefs
+          properties:
+            parentRefs:
+              items:
+                required:
+                  - name
     additionalProperties: false
   routeDefault:
     type: object
@@ -373,10 +383,6 @@ $defs:
               kind:
                 type: string
                 const: Gateway
-              name:
-                type: string
-                maxLength: 63
-                pattern: "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               namespace:
                 type: string
                 const: shared-gateways

--- a/charts/gatewayapi/templates/healthcheckpolicy.yaml
+++ b/charts/gatewayapi/templates/healthcheckpolicy.yaml
@@ -16,7 +16,7 @@ kind: HealthCheckPolicy
 metadata:
   labels:
     {{- $labels | nindent 4 }}
-  name: {{ $commonName }}-{{ $healthCheckPolicyDefinition.name }}
+  name: {{ $healthCheckPolicyDefinition.name }}
 spec:
 {{- if and $healthCheckPolicyDefinition.spec $healthCheckPolicyDefinition.rawSpec }}
   {{- toYaml $healthCheckPolicyDefinition.spec | nindent 2 }}

--- a/charts/gatewayapi/templates/httproute.yaml
+++ b/charts/gatewayapi/templates/httproute.yaml
@@ -16,7 +16,7 @@ kind: HTTPRoute
 metadata:
   labels:
     {{- $labels | nindent 4 }}
-  name: {{ $commonName }}-{{ $routeDefinition.name }}
+  name: {{ $routeDefinition.name }}
 spec:
 {{- if (and $routeDefinition.spec $routeDefinition.rawSpec) }}
   {{- toYaml $routeDefinition.spec | nindent 2 -}}

--- a/charts/gatewayapi/templates/httproute.yaml
+++ b/charts/gatewayapi/templates/httproute.yaml
@@ -26,19 +26,12 @@ spec:
     - {{ . }}
     {{- end }}
   parentRefs:
-  {{- if $routeDefinition.spec.parentRefs }}
     {{- range $routeDefinition.spec.parentRefs }}
   - group: {{ .group | default $.Values.routes.default.spec.parentRef.group }}
     kind: {{ .kind | default $.Values.routes.default.spec.parentRef.kind }}
-    name: {{ .name | default $.Values.routes.default.spec.parentRef.name }}
+    name: {{ .name }}
     namespace: {{ .namespace | default $.Values.routes.default.spec.parentRef.namespace }}
     {{- end }}
-  {{- else }}
-  - group: {{ $.Values.routes.default.spec.parentRef.group }}
-    kind: {{ $.Values.routes.default.spec.parentRef.kind }}
-    name: {{ $.Values.routes.default.spec.parentRef.name }}
-    namespace: {{ $.Values.routes.default.spec.parentRef.namespace }}
-  {{- end }}
   rules:
     {{- range $routeDefinition.spec.rules }}
     -

--- a/charts/gatewayapi/values.schema.json
+++ b/charts/gatewayapi/values.schema.json
@@ -40,11 +40,6 @@
                       "type": "string",
                       "const": "Gateway"
                     },
-                    "name": {
-                      "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
-                    },
                     "namespace": {
                       "type": "string",
                       "const": "shared-gateways"
@@ -423,6 +418,24 @@
                             }
                           }
                         }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "spec": {
+                  "required": [
+                    "parentRefs"
+                  ],
+                  "properties": {
+                    "parentRefs": {
+                      "items": {
+                        "required": [
+                          "name"
+                        ]
                       }
                     }
                   }

--- a/charts/gatewayapi/values.yaml
+++ b/charts/gatewayapi/values.yaml
@@ -91,7 +91,6 @@ routes:
       parentRef:
         group: gateway.networking.k8s.io
         kind: Gateway
-        name: default
         namespace: shared-gateways
       rule:
         backendRef:

--- a/charts/gatewayapi/values.yaml
+++ b/charts/gatewayapi/values.yaml
@@ -23,8 +23,8 @@ gateways:
         # Overrides defaultNamespace for this reference
         namespace: shared-gateways
 
-# HealthCheckPolicies list. Each item's `name` becomes the suffix of the rendered
-# resource (e.g. `<release>-<name>`). Names must be unique across items.
+# HealthCheckPolicies list. Each item's `name` becomes the name of the rendered
+# resource (e.g. `<name>`). Names must be unique across items.
 healthCheckPolicies:
   enabled: true
   # When an items entry rawSpec is false, the spec block will be merged with defaults defined here.
@@ -80,8 +80,8 @@ healthCheckPolicies:
 #        kind: Service
 #        name: example-service
 
-# Routes list. Each item's `name` becomes the suffix of the rendered route resource
-# (e.g. `<release>-<name>`). Names must be unique across items. Each entry must
+# Routes list. Each item's `name` becomes the name of the rendered route resource
+# (e.g. `<name>`). Names must be unique across items. Each entry must
 # declare its `kind` (HTTPRoute or GRPCRoute) and a `spec` block.
 routes:
   enabled: true
@@ -112,6 +112,8 @@ routes:
 #      hostnames:
 #        - example-service.daveapi.io
 #        - example-service.daveapi.com
+#      parentRefs:
+#        - name: default
 #      rules:
 #        - backendRefs:
 #            - name: example-service


### PR DESCRIPTION
**Ticket**
[SRE-6902](https://demoforthedaves.atlassian.net/browse/SRE-6902)

**Ticket and brief summary**
- `gatewayapi` chart v2.2.0
- Simplify names for `HTTPRoute` and `HealthCheckPolicy` resources.
- Having a default Gateway name at this stage is not a good idea

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[SRE-6902]: https://demoforthedaves.atlassian.net/browse/SRE-6902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ