### PR TITLE
[SRE-7089] `gateway-bundle` chart v2.1.0

### DIFF
--- a/charts/gateway-bundle/Chart.yaml
+++ b/charts/gateway-bundle/Chart.yaml
@@ -16,5 +16,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0-alpha.0
+version: 2.1.0
 appVersion: "0.1.0"

--- a/charts/gateway-bundle/Chart.yaml
+++ b/charts/gateway-bundle/Chart.yaml
@@ -16,5 +16,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0-alpha.0
 appVersion: "0.1.0"

--- a/charts/gateway-bundle/README.md
+++ b/charts/gateway-bundle/README.md
@@ -61,24 +61,23 @@ At most 15 SSL certificate(s) (N in the request) can be specified for
 TargetHttpsProxy patch.
 ```
 
-Set `gateways.default.tlsSecretGroups` to collapse listeners onto shared
+Set `gateways.default.ext.tlsSecretGroups` to collapse listeners onto shared
 Secrets by parent domain:
 
 ```yaml
 gateways:
   default:
-    tlsSecretGroups:
-      - parentDomain: trydave.com
-        secretName: shared-trydave-com-tls
-      - parentDomain: daveapi.com
-        secretName: shared-daveapi-com-tls
-      - parentDomain: daveapi.io
-        secretName: shared-daveapi-io-tls
+    ext:
+      tlsSecretGroups:
+        - parentDomain: trydave.com
+        - parentDomain: daveapi.com
+        - parentDomain: daveapi.io
 ```
 
 A listener whose hostname matches `<parentDomain>` or `*.<parentDomain>`
-uses the corresponding `secretName` instead of the per-listener name. With
-the `cert-manager.io/cluster-issuer` annotation in place, cert-manager's
+uses a secret named `<parentDomain>-<gatewayName>-tls` instead of the
+per-listener name. The dots are replaced with dashes. With the
+`cert-manager.io/cluster-issuer` annotation in place, cert-manager's
 gateway-shim issues a single multi-SAN `Certificate` per shared Secret —
 collapsing N listeners onto 1 cert slot on the underlying proxy.
 

--- a/charts/gateway-bundle/README.md
+++ b/charts/gateway-bundle/README.md
@@ -49,6 +49,42 @@ is merged with the chart defaults:
   `cert-manager.io/cluster-issuer` annotation on `gateways.default.metadata`
   (the default annotation on a clean install is `letsencrypt`).
 
+### Sharing TLS Secrets across listeners
+
+GKE caps each `TargetHttpsProxy` (one per `Gateway`) at **15 SSL
+certificates**. Since the per-listener Secret naming above produces one cert
+per listener, a Gateway with more than 15 HTTPS listeners will fail to
+reconcile with an error like:
+
+```
+At most 15 SSL certificate(s) (N in the request) can be specified for
+TargetHttpsProxy patch.
+```
+
+Set `gateways.default.tlsSecretGroups` to collapse listeners onto shared
+Secrets by parent domain:
+
+```yaml
+gateways:
+  default:
+    tlsSecretGroups:
+      - parentDomain: trydave.com
+        secretName: shared-trydave-com-tls
+      - parentDomain: daveapi.com
+        secretName: shared-daveapi-com-tls
+      - parentDomain: daveapi.io
+        secretName: shared-daveapi-io-tls
+```
+
+A listener whose hostname matches `<parentDomain>` or `*.<parentDomain>`
+uses the corresponding `secretName` instead of the per-listener name. With
+the `cert-manager.io/cluster-issuer` annotation in place, cert-manager's
+gateway-shim issues a single multi-SAN `Certificate` per shared Secret —
+collapsing N listeners onto 1 cert slot on the underlying proxy.
+
+Precedence: an explicit per-listener `tls` block wins; otherwise the first
+matching group is used; otherwise the per-listener fallback name applies.
+
 You will notice there is no mention of `HTTPRoute` or `HealthCheckPolicy`
 above. That's because routes and health checks are managed elsewhere — see
 the [`gatewayapi`](../gatewayapi) helm chart.
@@ -84,6 +120,7 @@ The examples cover:
 | [simple.yaml](./examples/simple.yaml) | Minimal single-Gateway with one HTTPS listener |
 | [multi-hostname.yaml](./examples/multi-hostname.yaml) | One Gateway hosting several HTTPS hostnames |
 | [per-listener-overrides.yaml](./examples/per-listener-overrides.yaml) | HTTP, Same-namespace, and caller-managed-TLS listeners on one Gateway |
+| [shared-tls-secrets.yaml](./examples/shared-tls-secrets.yaml) | Many listeners sharing TLS Secrets by parent domain (stays under GKE's 15-cert limit) |
 | [raw-spec.yaml](./examples/raw-spec.yaml) | `rawSpec: true` escape hatch for full Gateway-spec control |
 
 You can also apply `additionalLabels` to have extra labels added to all

--- a/charts/gateway-bundle/README.md
+++ b/charts/gateway-bundle/README.md
@@ -43,11 +43,14 @@ is merged with the chart defaults:
 - `name` is auto-derived from the hostname and protocol (e.g.
   `example-service-trydave-com-https`).
 - For HTTPS listeners that don't declare a `tls` block, the chart
-  auto-generates `tls.certificateRefs` with a Secret named
-  `{hostname}-{item-name}-tls` (dots replaced with dashes, truncated to 63
-  characters). Pair this with cert-manager via the
-  `cert-manager.io/cluster-issuer` annotation on `gateways.default.metadata`
-  (the default annotation on a clean install is `letsencrypt`).
+  auto-generates `tls.certificateRefs`. By default the Secret name comes
+  from the matching `tlsSecretGroups` entry (see below) —
+  `{parentDomain}-{item-name}-tls`. Listeners whose hostname doesn't match
+  any group fall back to `{hostname}-{item-name}-tls`. In both cases dots
+  are replaced with dashes and the name is truncated to 63 characters.
+  Pair this with cert-manager via the `cert-manager.io/cluster-issuer`
+  annotation on `gateways.default.metadata` (the default annotation on a
+  clean install is `letsencrypt`).
 
 ### Sharing TLS Secrets across listeners
 
@@ -61,28 +64,37 @@ At most 15 SSL certificate(s) (N in the request) can be specified for
 TargetHttpsProxy patch.
 ```
 
-Set `gateways.default.ext.tlsSecretGroups` to collapse listeners onto shared
-Secrets by parent domain:
+`gateways.default.ext.tlsSecretGroups` (enabled by default — see
+[values.yaml](./values.yaml)) collapses listeners onto shared Secrets by
+parent domain:
 
 ```yaml
 gateways:
   default:
     ext:
       tlsSecretGroups:
-        - parentDomain: trydave.com
-        - parentDomain: daveapi.com
-        - parentDomain: daveapi.io
+        enabled: true
+        items:
+          - parentDomain: trydave.com
+          - parentDomain: daveapi.com
+          - parentDomain: daveapi.io
 ```
 
 A listener whose hostname matches `<parentDomain>` or `*.<parentDomain>`
-uses a secret named `<parentDomain>-<gatewayName>-tls` instead of the
-per-listener name. The dots are replaced with dashes. With the
+uses a Secret named `<parentDomain>-<gatewayName>-tls` (dots replaced with
+dashes, truncated to 63 chars) instead of the per-listener name. With the
 `cert-manager.io/cluster-issuer` annotation in place, cert-manager's
 gateway-shim issues a single multi-SAN `Certificate` per shared Secret —
 collapsing N listeners onto 1 cert slot on the underlying proxy.
 
 Precedence: an explicit per-listener `tls` block wins; otherwise the first
 matching group is used; otherwise the per-listener fallback name applies.
+Set `enabled: false` to keep per-listener Secret names everywhere.
+
+If you need a Secret name the generator can't produce (e.g. a pre-existing
+Secret that doesn't follow the `<parentDomain>-<gatewayName>-tls` pattern),
+declare the listener's `tls` block inline — the explicit block always wins
+over the auto-generated name.
 
 You will notice there is no mention of `HTTPRoute` or `HealthCheckPolicy`
 above. That's because routes and health checks are managed elsewhere — see

--- a/charts/gateway-bundle/README.md
+++ b/charts/gateway-bundle/README.md
@@ -100,6 +100,31 @@ You will notice there is no mention of `HTTPRoute` or `HealthCheckPolicy`
 above. That's because routes and health checks are managed elsewhere — see
 the [`gatewayapi`](../gatewayapi) helm chart.
 
+### Custom addresses
+
+Set `spec.addresses` on an item to bind the Gateway to a caller-specified
+IP, hostname, or implementation-named address (e.g. a pre-reserved GCP
+static IP):
+
+```yaml
+gateways:
+  items:
+    - name: default
+      spec:
+        addresses:
+          - type: IPAddress
+            value: 127.0.0.1
+          - type: NamedAddress
+            value: my-reserved-gcp-static-ip
+        listeners:
+          - hostname: example-service.trydave.com
+```
+
+`type` is one of `IPAddress`, `Hostname`, or `NamedAddress`. This works
+without `rawSpec: true`, so listener defaults and `tlsSecretGroups` still
+apply. For implementation-specific `<group>/<type>` values, drop into
+`rawSpec: true`.
+
 ### Full spec control
 
 By default, each item's spec is merged with the chart defaults. Set
@@ -132,6 +157,7 @@ The examples cover:
 | [multi-hostname.yaml](./examples/multi-hostname.yaml) | One Gateway hosting several HTTPS hostnames |
 | [per-listener-overrides.yaml](./examples/per-listener-overrides.yaml) | HTTP, Same-namespace, and caller-managed-TLS listeners on one Gateway |
 | [shared-tls-secrets.yaml](./examples/shared-tls-secrets.yaml) | Many listeners sharing TLS Secrets by parent domain (stays under GKE's 15-cert limit) |
+| [custom-addresses.yaml](./examples/custom-addresses.yaml) | Bind a Gateway to a specific IP or named address via `spec.addresses` |
 | [raw-spec.yaml](./examples/raw-spec.yaml) | `rawSpec: true` escape hatch for full Gateway-spec control |
 
 You can also apply `additionalLabels` to have extra labels added to all

--- a/charts/gateway-bundle/examples/README.md
+++ b/charts/gateway-bundle/examples/README.md
@@ -17,10 +17,11 @@ expressive enough.
   and TLS. Useful as a reference for any non-default listener configuration
   without leaving the chart's templated mode.
 - [shared-tls-secrets](./shared-tls-secrets.yaml): Many HTTPS listeners
-  sharing TLS Secrets by parent domain via `gateways.default.tlsSecretGroups`.
-  Collapses N per-listener certs into one multi-SAN cert per shared Secret
-  (via cert-manager's gateway-shim) so the Gateway stays under GKE's
-  15-SSL-certificate cap on the underlying `TargetHttpsProxy`.
+  sharing TLS Secrets by parent domain via
+  `gateways.default.ext.tlsSecretGroups`. Collapses N per-listener certs
+  into one multi-SAN cert per shared Secret (via cert-manager's
+  gateway-shim) so the Gateway stays under GKE's 15-SSL-certificate cap
+  on the underlying `TargetHttpsProxy`.
 - [raw-spec](./raw-spec.yaml): An escape hatch that sets `rawSpec: true`
   and supplies the entire Gateway spec verbatim. Use this when the chart's
   templated mode can't express what you need; metadata is still inherited

--- a/charts/gateway-bundle/examples/README.md
+++ b/charts/gateway-bundle/examples/README.md
@@ -22,6 +22,10 @@ expressive enough.
   into one multi-SAN cert per shared Secret (via cert-manager's
   gateway-shim) so the Gateway stays under GKE's 15-SSL-certificate cap
   on the underlying `TargetHttpsProxy`.
+- [custom-addresses](./custom-addresses.yaml): Bind a Gateway to one or
+  more caller-specified addresses (e.g. a pre-reserved GCP static IP or
+  an implementation-named address) via `spec.addresses`. Stays in
+  templated mode — listener defaults and `tlsSecretGroups` still apply.
 - [raw-spec](./raw-spec.yaml): An escape hatch that sets `rawSpec: true`
   and supplies the entire Gateway spec verbatim. Use this when the chart's
   templated mode can't express what you need; metadata is still inherited

--- a/charts/gateway-bundle/examples/README.md
+++ b/charts/gateway-bundle/examples/README.md
@@ -16,6 +16,11 @@ expressive enough.
   whose listeners selectively override port, protocol, `allowedRoutes`,
   and TLS. Useful as a reference for any non-default listener configuration
   without leaving the chart's templated mode.
+- [shared-tls-secrets](./shared-tls-secrets.yaml): Many HTTPS listeners
+  sharing TLS Secrets by parent domain via `gateways.default.tlsSecretGroups`.
+  Collapses N per-listener certs into one multi-SAN cert per shared Secret
+  (via cert-manager's gateway-shim) so the Gateway stays under GKE's
+  15-SSL-certificate cap on the underlying `TargetHttpsProxy`.
 - [raw-spec](./raw-spec.yaml): An escape hatch that sets `rawSpec: true`
   and supplies the entire Gateway spec verbatim. Use this when the chart's
   templated mode can't express what you need; metadata is still inherited

--- a/charts/gateway-bundle/examples/custom-addresses.yaml
+++ b/charts/gateway-bundle/examples/custom-addresses.yaml
@@ -1,0 +1,19 @@
+# Bind a Gateway to one or more caller-specified addresses (e.g. a
+# pre-reserved GCP static IP, or an implementation-named address) via
+# Gateway-API's `spec.addresses`. Each entry is `{type, value}` where
+# `type` is one of `IPAddress`, `Hostname`, or `NamedAddress`. This
+# stays in templated mode — listener defaults, auto-naming, and
+# `tlsSecretGroups` all still apply. For implementation-specific
+# `<group>/<type>` values, use `raw-spec.yaml` instead.
+enabled: true
+gateways:
+  items:
+    - name: default
+      spec:
+        addresses:
+          - type: IPAddress
+            value: 127.0.0.1
+          - type: NamedAddress
+            value: my-reserved-gcp-static-ip
+        listeners:
+          - hostname: example-service.trydave.com

--- a/charts/gateway-bundle/examples/multi-hostname.yaml
+++ b/charts/gateway-bundle/examples/multi-hostname.yaml
@@ -1,12 +1,20 @@
 # Single Gateway hosting several HTTPS listeners. Each listener entry is just
 # a hostname; the chart fills in `name`, `port`, `protocol`, `allowedRoutes`,
-# and an auto-generated TLS cert ref (one Secret per hostname, suffixed with
-# the Gateway item name).
+# and an auto-generated TLS cert ref.
 #
-# This is the recommended shape when a team owns many hostnames that should
-# all sit behind one Gateway resource (subject to the 64-listener API limit).
+# `tlsSecretGroups` is disabled here so each hostname gets its own Secret
+# (e.g. `service-a-trydave-com-default-tls`). See `shared-tls-secrets.yaml`
+# for the opposite shape, where listeners collapse onto shared Secrets by
+# parent domain.
+#
+# Use this shape when each hostname owns its own cert and you're comfortably
+# under GKE's 15-SSL-certificate cap on the underlying TargetHttpsProxy.
 enabled: true
 gateways:
+  default:
+    ext:
+      tlsSecretGroups:
+        enabled: false
   items:
     - name: default
       spec:

--- a/charts/gateway-bundle/examples/shared-tls-secrets.yaml
+++ b/charts/gateway-bundle/examples/shared-tls-secrets.yaml
@@ -1,0 +1,44 @@
+# Single Gateway with many HTTPS listeners that share TLS Secrets by parent
+# domain. Useful when the listener count would otherwise exceed GKE's
+# 15-SSL-certificate cap per TargetHttpsProxy.
+#
+# Each `tlsSecretGroups` entry maps a parent domain to a single Secret name.
+# A listener whose hostname matches `<parentDomain>` or `*.<parentDomain>`
+# uses the shared Secret instead of the auto-generated per-listener name.
+# With cert-manager's gateway-shim (driven by the
+# `cert-manager.io/cluster-issuer` annotation on `gateways.default`), all
+# listeners sharing a Secret are issued a single multi-SAN Certificate.
+#
+# Listeners with no matching group fall back to per-listener Secret naming;
+# listeners with an explicit `tls` block bypass groups entirely.
+#
+# Result here: 7 HTTPS listeners across 3 parent domains collapse to 3
+# shared Secrets (+1 caller-managed Secret) on the rendered Gateway.
+enabled: true
+gateways:
+  default:
+    tlsSecretGroups:
+      - parentDomain: trydave.com
+        secretName: shared-trydave-com-tls
+      - parentDomain: daveapi.com
+        secretName: shared-daveapi-com-tls
+      - parentDomain: daveapi.io
+        secretName: shared-daveapi-io-tls
+  items:
+    - name: default
+      spec:
+        listeners:
+          - hostname: service-a.trydave.com
+          - hostname: service-b.trydave.com
+          - hostname: service-c.trydave.com
+          - hostname: service-d.daveapi.com
+          - hostname: service-e.daveapi.com
+          - hostname: service-f.daveapi.io
+          # Caller-managed TLS still wins — this listener ignores the group.
+          - hostname: legacy.daveapi.io
+            tls:
+              certificateRefs:
+                - group: ""
+                  kind: Secret
+                  name: legacy-daveapi-io-managed-tls
+              mode: Terminate

--- a/charts/gateway-bundle/examples/shared-tls-secrets.yaml
+++ b/charts/gateway-bundle/examples/shared-tls-secrets.yaml
@@ -2,18 +2,24 @@
 # domain. Useful when the listener count would otherwise exceed GKE's
 # 15-SSL-certificate cap per TargetHttpsProxy.
 #
-# Each `tlsSecretGroups` entry maps a parent domain to a single Secret name.
-# A listener whose hostname matches `<parentDomain>` or `*.<parentDomain>`
-# uses the shared Secret instead of the auto-generated per-listener name.
-# With cert-manager's gateway-shim (driven by the
-# `cert-manager.io/cluster-issuer` annotation on `gateways.default`), all
-# listeners sharing a Secret are issued a single multi-SAN Certificate.
+# Each `tlsSecretGroups.items` entry lists a parent domain. A listener
+# whose hostname matches `<parentDomain>` or `*.<parentDomain>` uses a
+# Secret named `<parentDomain>-<gatewayName>-tls` (dots replaced with
+# dashes, truncated to 63 chars). With cert-manager's gateway-shim
+# (driven by the `cert-manager.io/cluster-issuer` annotation on
+# `gateways.default`), all listeners sharing a Secret are issued a single
+# multi-SAN Certificate.
 #
 # Listeners with no matching group fall back to per-listener Secret naming;
 # listeners with an explicit `tls` block bypass groups entirely.
 #
 # Result here: 7 HTTPS listeners across 3 parent domains collapse to 3
 # shared Secrets (+1 caller-managed Secret) on the rendered Gateway.
+#
+# Note: `tlsSecretGroups.enabled: true` is also the chart default, so this
+# example is functionally redundant with the bare `simple.yaml` /
+# `multi-hostname.yaml` shape — it's included to make the grouping
+# behavior explicit and to demonstrate the caller-managed-TLS override.
 enabled: true
 gateways:
   default:

--- a/charts/gateway-bundle/examples/shared-tls-secrets.yaml
+++ b/charts/gateway-bundle/examples/shared-tls-secrets.yaml
@@ -19,9 +19,11 @@ gateways:
   default:
     ext:
       tlsSecretGroups:
-        - parentDomain: trydave.com
-        - parentDomain: daveapi.com
-        - parentDomain: daveapi.io
+        enabled: true
+        items:
+          - parentDomain: trydave.com
+          - parentDomain: daveapi.com
+          - parentDomain: daveapi.io
   items:
     - name: default
       spec:

--- a/charts/gateway-bundle/examples/shared-tls-secrets.yaml
+++ b/charts/gateway-bundle/examples/shared-tls-secrets.yaml
@@ -16,14 +16,6 @@
 # shared Secrets (+1 caller-managed Secret) on the rendered Gateway.
 enabled: true
 gateways:
-  default:
-    tlsSecretGroups:
-      - parentDomain: trydave.com
-        secretName: shared-trydave-com-tls
-      - parentDomain: daveapi.com
-        secretName: shared-daveapi-com-tls
-      - parentDomain: daveapi.io
-        secretName: shared-daveapi-io-tls
   items:
     - name: default
       spec:

--- a/charts/gateway-bundle/examples/shared-tls-secrets.yaml
+++ b/charts/gateway-bundle/examples/shared-tls-secrets.yaml
@@ -16,6 +16,12 @@
 # shared Secrets (+1 caller-managed Secret) on the rendered Gateway.
 enabled: true
 gateways:
+  default:
+    ext:
+      tlsSecretGroups:
+        - parentDomain: trydave.com
+        - parentDomain: daveapi.com
+        - parentDomain: daveapi.io
   items:
     - name: default
       spec:

--- a/charts/gateway-bundle/examples/simple.yaml
+++ b/charts/gateway-bundle/examples/simple.yaml
@@ -1,8 +1,11 @@
 # Minimal Gateway deployment: creates a single Gateway named `default`
 # with one HTTPS listener for `example-service.trydave.com`. Relies on chart
-# defaults for `gatewayClassName`, `port`, `protocol`, `allowedRoutes`, and an
-# auto-generated `tls.certificateRefs` entry (named
-# `example-service-trydave-com-default-tls`).
+# defaults for `gatewayClassName`, `port`, `protocol`, `allowedRoutes`, and
+# an auto-generated `tls.certificateRefs` entry. The default config enables
+# `tlsSecretGroups`, so the rendered Secret name is the shared
+# `trydave-com-default-tls` (parent-domain grouping). Override
+# `gateways.default.ext.tlsSecretGroups.enabled` to `false` to get
+# per-listener names — see `multi-hostname.yaml`.
 enabled: true
 gateways:
   items:

--- a/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
+++ b/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
@@ -20,6 +20,10 @@ required:
   - gateways
 
 $defs:
+  parentDomain:
+    type: string
+    pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+
   gatewayDefault:
     type: object
     properties:
@@ -84,15 +88,29 @@ $defs:
                 type: boolean
               items:
                 type: array
+                minItems: 1
                 items:
                   type: object
                   properties:
                     parentDomain:
-                      type: string
-                      pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+                      $ref: "#/$defs/parentDomain"
                   required:
                     - parentDomain
                   additionalProperties: false
+            required:
+              - enabled
+            # `items` is required only when `enabled: true` — there's no
+            # point forcing a placeholder list when grouping is off.
+            if:
+              properties:
+                enabled:
+                  const: true
+              required:
+                - enabled
+            then:
+              required:
+                - items
+            additionalProperties: false
         additionalProperties: false
     required:
       - spec
@@ -163,6 +181,9 @@ $defs:
     properties:
       hostname:
         type: string
+        # The parent-domain alternation (trydave.com|daveapi.com|daveapi.io)
+        # also lives in $defs/parentDomain — keep both in sync when the
+        # allow-list changes.
         pattern: "^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\\.)*(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
       name:
         type: string

--- a/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
+++ b/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
@@ -85,12 +85,8 @@ $defs:
                 parentDomain:
                   type: string
                   pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
-                secretName:
-                  type: string
-                  maxLength: 253
               required:
                 - parentDomain
-                - secretName
               additionalProperties: false
         additionalProperties: false
     required:

--- a/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
+++ b/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
@@ -132,6 +132,11 @@ $defs:
         properties:
           gatewayClassName:
             type: string
+          addresses:
+            type: array
+            minItems: 1
+            items:
+              $ref: "#/$defs/address"
           listeners:
             type: array
             minItems: 1
@@ -174,6 +179,26 @@ $defs:
               items:
                 required:
                   - hostname
+    additionalProperties: false
+
+  address:
+    type: object
+    properties:
+      # Implementation-specific custom types (`<group>/<type>`) are not
+      # accepted here — drop into `rawSpec: true` if you need one.
+      type:
+        type: string
+        enum:
+          - IPAddress
+          - Hostname
+          - NamedAddress
+      value:
+        type: string
+        minLength: 1
+        maxLength: 253
+    required:
+      - type
+      - value
     additionalProperties: false
 
   listener:

--- a/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
+++ b/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
@@ -78,16 +78,21 @@ $defs:
         type: object
         properties:
           tlsSecretGroups:
-            type: array
-            items:
-              type: object
-              properties:
-                parentDomain:
-                  type: string
-                  pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
-              required:
-                - parentDomain
-              additionalProperties: false
+            type: object
+            properties:
+              enabled:
+                type: boolean
+              items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    parentDomain:
+                      type: string
+                      pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+                  required:
+                    - parentDomain
+                  additionalProperties: false
         additionalProperties: false
     required:
       - spec

--- a/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
+++ b/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
@@ -74,6 +74,21 @@ $defs:
           - gatewayClassName
           - listener
         additionalProperties: false
+      tlsSecretGroups:
+        type: array
+        items:
+          type: object
+          properties:
+            parentDomain:
+              type: string
+              pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+            secretName:
+              type: string
+              maxLength: 253
+          required:
+            - parentDomain
+            - secretName
+          additionalProperties: false
     required:
       - spec
     additionalProperties: false

--- a/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
+++ b/charts/gateway-bundle/schemas/gateway-bundle.schema.yaml
@@ -74,21 +74,25 @@ $defs:
           - gatewayClassName
           - listener
         additionalProperties: false
-      tlsSecretGroups:
-        type: array
-        items:
-          type: object
-          properties:
-            parentDomain:
-              type: string
-              pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
-            secretName:
-              type: string
-              maxLength: 253
-          required:
-            - parentDomain
-            - secretName
-          additionalProperties: false
+      ext:
+        type: object
+        properties:
+          tlsSecretGroups:
+            type: array
+            items:
+              type: object
+              properties:
+                parentDomain:
+                  type: string
+                  pattern: "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+                secretName:
+                  type: string
+                  maxLength: 253
+              required:
+                - parentDomain
+                - secretName
+              additionalProperties: false
+        additionalProperties: false
     required:
       - spec
     additionalProperties: false

--- a/charts/gateway-bundle/templates/_helpers.tpl
+++ b/charts/gateway-bundle/templates/_helpers.tpl
@@ -38,3 +38,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "gateway-bundle.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+TLS Secret name for an HTTPS listener.
+Inputs: { name, gateway } — `name` is either the listener hostname (per-listener
+fallback) or a matched `parentDomain` (shared-group path). Produces
+"<name>-<gateway>-tls" with dots replaced by dashes and truncated to 63 chars
+(the DNS-1123 label limit Kubernetes enforces on Secret names).
+*/}}
+{{- define "gateway-bundle.tlsSecretName" -}}
+{{- printf "%s-%s-tls" .name .gateway | replace "." "-" | trunc 63 -}}
+{{- end }}

--- a/charts/gateway-bundle/templates/gateways.yaml
+++ b/charts/gateway-bundle/templates/gateways.yaml
@@ -29,6 +29,10 @@ spec:
   {{- toYaml $item.spec | nindent 2 }}
 {{- else }}
   gatewayClassName: {{ $item.spec.gatewayClassName | default $default.spec.gatewayClassName }}
+  {{- with $item.spec.addresses }}
+  addresses:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   listeners:
   {{- $lDef := $default.spec.listener }}
   {{- range $l := $item.spec.listeners }}

--- a/charts/gateway-bundle/templates/gateways.yaml
+++ b/charts/gateway-bundle/templates/gateways.yaml
@@ -46,8 +46,8 @@ spec:
       {{- toYaml $l.tls | nindent 6 }}
       {{- else }}
       {{- $secretName := "" }}
-      {{- range $g := ($default.ext.tlsSecretGroups | default list) }}
-        {{- if or (eq $l.hostname $g.parentDomain) (hasSuffix (printf ".%s" $g.parentDomain) $l.hostname) }}
+      {{- range $g := ($default.ext.tlsSecretGroups.items | default list) }}
+        {{- if (and $default.ext.tlsSecretGroups.enabled (or (eq $l.hostname $g.parentDomain) (hasSuffix (printf ".%s" $g.parentDomain) $l.hostname))) }}
           {{- $secretName = (printf "%s-%s-tls" $g.parentDomain $item.name) | replace "." "-" | trunc 63 }}
         {{- end }}
       {{- end }}

--- a/charts/gateway-bundle/templates/gateways.yaml
+++ b/charts/gateway-bundle/templates/gateways.yaml
@@ -45,10 +45,19 @@ spec:
       {{- if $l.tls }}
       {{- toYaml $l.tls | nindent 6 }}
       {{- else }}
+      {{- $secretName := "" }}
+      {{- range $g := ($default.tlsSecretGroups | default list) }}
+        {{- if or (eq $l.hostname $g.parentDomain) (hasSuffix (printf ".%s" $g.parentDomain) $l.hostname) }}
+          {{- $secretName = $g.secretName }}
+        {{- end }}
+      {{- end }}
+      {{- if not $secretName }}
+        {{- $secretName = (printf "%s-%s-tls" $l.hostname $item.name) | replace "." "-" | trunc 63 }}
+      {{- end }}
       certificateRefs:
         - group: ""
           kind: Secret
-          name: {{ (printf "%s-%s-tls" $l.hostname $item.name) | replace "." "-" | trunc 63 }}
+          name: {{ $secretName }}
       mode: Terminate
       {{- end }}
     {{- end }}

--- a/charts/gateway-bundle/templates/gateways.yaml
+++ b/charts/gateway-bundle/templates/gateways.yaml
@@ -46,9 +46,9 @@ spec:
       {{- toYaml $l.tls | nindent 6 }}
       {{- else }}
       {{- $secretName := "" }}
-      {{- range $g := ($default.tlsSecretGroups | default list) }}
+      {{- range $g := ($default.ext.tlsSecretGroups | default list) }}
         {{- if or (eq $l.hostname $g.parentDomain) (hasSuffix (printf ".%s" $g.parentDomain) $l.hostname) }}
-          {{- $secretName = $g.secretName }}
+          {{- $secretName = (printf "%s-%s-tls" $g.secretName $item.name) | replace "." "-" | trunc 63 }}
         {{- end }}
       {{- end }}
       {{- if not $secretName }}

--- a/charts/gateway-bundle/templates/gateways.yaml
+++ b/charts/gateway-bundle/templates/gateways.yaml
@@ -48,7 +48,7 @@ spec:
       {{- $secretName := "" }}
       {{- range $g := ($default.ext.tlsSecretGroups | default list) }}
         {{- if or (eq $l.hostname $g.parentDomain) (hasSuffix (printf ".%s" $g.parentDomain) $l.hostname) }}
-          {{- $secretName = (printf "%s-%s-tls" $g.secretName $item.name) | replace "." "-" | trunc 63 }}
+          {{- $secretName = (printf "%s-%s-tls" $g.parentDomain $item.name) | replace "." "-" | trunc 63 }}
         {{- end }}
       {{- end }}
       {{- if not $secretName }}

--- a/charts/gateway-bundle/templates/gateways.yaml
+++ b/charts/gateway-bundle/templates/gateways.yaml
@@ -46,13 +46,19 @@ spec:
       {{- toYaml $l.tls | nindent 6 }}
       {{- else }}
       {{- $secretName := "" }}
-      {{- range $g := ($default.ext.tlsSecretGroups.items | default list) }}
-        {{- if (and $default.ext.tlsSecretGroups.enabled (or (eq $l.hostname $g.parentDomain) (hasSuffix (printf ".%s" $g.parentDomain) $l.hostname))) }}
-          {{- $secretName = (printf "%s-%s-tls" $g.parentDomain $item.name) | replace "." "-" | trunc 63 }}
+      {{- /* Chained access on `$default.ext` is intentional: Helm's nil
+             tolerance lets callers omit the whole `ext` block. */ -}}
+      {{- if $default.ext.tlsSecretGroups.enabled }}
+        {{- range $g := ($default.ext.tlsSecretGroups.items | default list) }}
+          {{- if not $secretName }}
+            {{- if (or (eq $l.hostname $g.parentDomain) (hasSuffix (printf ".%s" $g.parentDomain) $l.hostname)) }}
+              {{- $secretName = include "gateway-bundle.tlsSecretName" (dict "name" $g.parentDomain "gateway" $item.name) }}
+            {{- end }}
+          {{- end }}
         {{- end }}
       {{- end }}
       {{- if not $secretName }}
-        {{- $secretName = (printf "%s-%s-tls" $l.hostname $item.name) | replace "." "-" | trunc 63 }}
+        {{- $secretName = include "gateway-bundle.tlsSecretName" (dict "name" $l.hostname "gateway" $item.name) }}
       {{- end }}
       certificateRefs:
         - group: ""

--- a/charts/gateway-bundle/values.schema.json
+++ b/charts/gateway-bundle/values.schema.json
@@ -104,6 +104,7 @@
                     },
                     "items": {
                       "type": "array",
+                      "minItems": 1,
                       "items": {
                         "type": "object",
                         "properties": {
@@ -118,7 +119,26 @@
                         "additionalProperties": false
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "if": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    },
+                    "required": [
+                      "enabled"
+                    ]
+                  },
+                  "then": {
+                    "required": [
+                      "items"
+                    ]
+                  },
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false

--- a/charts/gateway-bundle/values.schema.json
+++ b/charts/gateway-bundle/values.schema.json
@@ -92,6 +92,27 @@
                 "listener"
               ],
               "additionalProperties": false
+            },
+            "tlsSecretGroups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "parentDomain": {
+                    "type": "string",
+                    "pattern": "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+                  },
+                  "secretName": {
+                    "type": "string",
+                    "maxLength": 253
+                  }
+                },
+                "required": [
+                  "parentDomain",
+                  "secretName"
+                ],
+                "additionalProperties": false
+              }
             }
           },
           "required": [

--- a/charts/gateway-bundle/values.schema.json
+++ b/charts/gateway-bundle/values.schema.json
@@ -93,26 +93,32 @@
               ],
               "additionalProperties": false
             },
-            "tlsSecretGroups": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "parentDomain": {
-                    "type": "string",
-                    "pattern": "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
-                  },
-                  "secretName": {
-                    "type": "string",
-                    "maxLength": 253
+            "ext": {
+              "type": "object",
+              "properties": {
+                "tlsSecretGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "parentDomain": {
+                        "type": "string",
+                        "pattern": "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+                      },
+                      "secretName": {
+                        "type": "string",
+                        "maxLength": 253
+                      }
+                    },
+                    "required": [
+                      "parentDomain",
+                      "secretName"
+                    ],
+                    "additionalProperties": false
                   }
-                },
-                "required": [
-                  "parentDomain",
-                  "secretName"
-                ],
-                "additionalProperties": false
-              }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "required": [

--- a/charts/gateway-bundle/values.schema.json
+++ b/charts/gateway-bundle/values.schema.json
@@ -104,15 +104,10 @@
                       "parentDomain": {
                         "type": "string",
                         "pattern": "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
-                      },
-                      "secretName": {
-                        "type": "string",
-                        "maxLength": 253
                       }
                     },
                     "required": [
-                      "parentDomain",
-                      "secretName"
+                      "parentDomain"
                     ],
                     "additionalProperties": false
                   }

--- a/charts/gateway-bundle/values.schema.json
+++ b/charts/gateway-bundle/values.schema.json
@@ -172,6 +172,33 @@
                   "gatewayClassName": {
                     "type": "string"
                   },
+                  "addresses": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "IPAddress",
+                            "Hostname",
+                            "NamedAddress"
+                          ]
+                        },
+                        "value": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 253
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
                   "listeners": {
                     "type": "array",
                     "minItems": 1,

--- a/charts/gateway-bundle/values.schema.json
+++ b/charts/gateway-bundle/values.schema.json
@@ -97,19 +97,27 @@
               "type": "object",
               "properties": {
                 "tlsSecretGroups": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "parentDomain": {
-                        "type": "string",
-                        "pattern": "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
-                      }
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
                     },
-                    "required": [
-                      "parentDomain"
-                    ],
-                    "additionalProperties": false
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "parentDomain": {
+                            "type": "string",
+                            "pattern": "^(trydave\\.com|daveapi\\.com|daveapi\\.io)$"
+                          }
+                        },
+                        "required": [
+                          "parentDomain"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
                   }
                 }
               },

--- a/charts/gateway-bundle/values.yaml
+++ b/charts/gateway-bundle/values.yaml
@@ -15,24 +15,25 @@ gateways:
             from: All
         port: 443
         protocol: HTTPS
-    ## Optional. Groups HTTPS listeners by parent domain so they share a
-    ## single Secret instead of generating one Secret per listener. With
-    ## the `cert-manager.io/cluster-issuer` annotation above, cert-manager's
-    ## gateway-shim issues one multi-SAN Certificate per shared Secret,
-    ## collapsing many listeners into a single SSL certificate slot on the
-    ## underlying TargetHttpsProxy (GKE caps that at 15 per Gateway).
-    ##
-    ## A listener whose hostname matches `<parentDomain>` or
-    ## `*.<parentDomain>` will use the corresponding `secretName`. Listeners
-    ## with no matching group keep the per-listener Secret name. Listeners
-    ## with an explicit `tls` block are unaffected.
-    # tlsSecretGroups:
-    #   - parentDomain: trydave.com
-    #     secretName: shared-trydave-com-tls
-    #   - parentDomain: daveapi.com
-    #     secretName: shared-daveapi-com-tls
-    #   - parentDomain: daveapi.io
-    #     secretName: shared-daveapi-io-tls
+    ext:
+      ## Optional. Groups HTTPS listeners by parent domain so they share a
+      ## single Secret instead of generating one Secret per listener. With
+      ## the `cert-manager.io/cluster-issuer` annotation above, cert-manager's
+      ## gateway-shim issues one multi-SAN Certificate per shared Secret,
+      ## collapsing many listeners into a single SSL certificate slot on the
+      ## underlying TargetHttpsProxy (GKE caps that at 15 per Gateway).
+      ##
+      ## A listener whose hostname matches `<parentDomain>` or
+      ## `*.<parentDomain>` will use the corresponding `secretName`. Listeners
+      ## with no matching group keep the per-listener Secret name. Listeners
+      ## with an explicit `tls` block are unaffected.
+      tlsSecretGroups:
+        - parentDomain: trydave.com
+          secretName: trydave-com
+        - parentDomain: daveapi.com
+          secretName: daveapi-com
+        - parentDomain: daveapi.io
+          secretName: daveapi-io
   # Each item creates a Gateway resource.
   items: []
 ## This is the simplest case where the Gateway will be created using the

--- a/charts/gateway-bundle/values.yaml
+++ b/charts/gateway-bundle/values.yaml
@@ -24,9 +24,11 @@ gateways:
       ## underlying TargetHttpsProxy (GKE caps that at 15 per Gateway).
       ##
       ## A listener whose hostname matches `<parentDomain>` or
-      ## `*.<parentDomain>` will use the corresponding `secretName`. Listeners
-      ## with no matching group keep the per-listener Secret name. Listeners
-      ## with an explicit `tls` block are unaffected.
+      ## `*.<parentDomain>` will use a secret name of the matching the
+      ## following pattern: `<parentDomain>-<gatewayName>-tls. The dots are
+      ## replaced with dashes. Listeners with no matching group keep the
+      ## per-listener Secret name. Listeners with an explicit `tls` block are
+      ## unaffected.
       tlsSecretGroups:
         - parentDomain: trydave.com
         - parentDomain: daveapi.com

--- a/charts/gateway-bundle/values.yaml
+++ b/charts/gateway-bundle/values.yaml
@@ -16,19 +16,23 @@ gateways:
         port: 443
         protocol: HTTPS
     ext:
-      ## Optional. Groups HTTPS listeners by parent domain so they share a
-      ## single Secret instead of generating one Secret per listener. With
-      ## the `cert-manager.io/cluster-issuer` annotation above, cert-manager's
+      ## Groups HTTPS listeners by parent domain so they share a single
+      ## Secret instead of generating one Secret per listener. With the
+      ## `cert-manager.io/cluster-issuer` annotation above, cert-manager's
       ## gateway-shim issues one multi-SAN Certificate per shared Secret,
       ## collapsing many listeners into a single SSL certificate slot on the
       ## underlying TargetHttpsProxy (GKE caps that at 15 per Gateway).
       ##
       ## A listener whose hostname matches `<parentDomain>` or
-      ## `*.<parentDomain>` will use a secret name of the matching the
-      ## following pattern: `<parentDomain>-<gatewayName>-tls. The dots are
-      ## replaced with dashes. Listeners with no matching group keep the
-      ## per-listener Secret name. Listeners with an explicit `tls` block are
-      ## unaffected.
+      ## `*.<parentDomain>` uses a Secret named
+      ## `<parentDomain>-<gatewayName>-tls` (dots replaced with dashes,
+      ## truncated to 63 chars). The first matching group wins. Listeners
+      ## with no matching group fall back to the per-listener Secret name
+      ## (`<hostname>-<gatewayName>-tls`). Listeners with an explicit `tls`
+      ## block bypass grouping entirely.
+      ##
+      ## Set `enabled: false` to disable grouping and keep per-listener
+      ## Secret names everywhere.
       tlsSecretGroups:
         enabled: true
         items:

--- a/charts/gateway-bundle/values.yaml
+++ b/charts/gateway-bundle/values.yaml
@@ -30,9 +30,11 @@ gateways:
       ## per-listener Secret name. Listeners with an explicit `tls` block are
       ## unaffected.
       tlsSecretGroups:
-        - parentDomain: trydave.com
-        - parentDomain: daveapi.com
-        - parentDomain: daveapi.io
+        enabled: true
+        items:
+          - parentDomain: trydave.com
+          - parentDomain: daveapi.com
+          - parentDomain: daveapi.io
   # Each item creates a Gateway resource.
   items: []
 ## This is the simplest case where the Gateway will be created using the

--- a/charts/gateway-bundle/values.yaml
+++ b/charts/gateway-bundle/values.yaml
@@ -15,6 +15,24 @@ gateways:
             from: All
         port: 443
         protocol: HTTPS
+    ## Optional. Groups HTTPS listeners by parent domain so they share a
+    ## single Secret instead of generating one Secret per listener. With
+    ## the `cert-manager.io/cluster-issuer` annotation above, cert-manager's
+    ## gateway-shim issues one multi-SAN Certificate per shared Secret,
+    ## collapsing many listeners into a single SSL certificate slot on the
+    ## underlying TargetHttpsProxy (GKE caps that at 15 per Gateway).
+    ##
+    ## A listener whose hostname matches `<parentDomain>` or
+    ## `*.<parentDomain>` will use the corresponding `secretName`. Listeners
+    ## with no matching group keep the per-listener Secret name. Listeners
+    ## with an explicit `tls` block are unaffected.
+    # tlsSecretGroups:
+    #   - parentDomain: trydave.com
+    #     secretName: shared-trydave-com-tls
+    #   - parentDomain: daveapi.com
+    #     secretName: shared-daveapi-com-tls
+    #   - parentDomain: daveapi.io
+    #     secretName: shared-daveapi-io-tls
   # Each item creates a Gateway resource.
   items: []
 ## This is the simplest case where the Gateway will be created using the

--- a/charts/gateway-bundle/values.yaml
+++ b/charts/gateway-bundle/values.yaml
@@ -29,11 +29,8 @@ gateways:
       ## with an explicit `tls` block are unaffected.
       tlsSecretGroups:
         - parentDomain: trydave.com
-          secretName: trydave-com
         - parentDomain: daveapi.com
-          secretName: daveapi-com
         - parentDomain: daveapi.io
-          secretName: daveapi-io
   # Each item creates a Gateway resource.
   items: []
 ## This is the simplest case where the Gateway will be created using the


### PR DESCRIPTION
**Ticket**
[SRE-7089](https://demoforthedaves.atlassian.net/browse/SRE-7089)

**Ticket and brief summary**
- `gateway-bundle` chart v2.1.0
- Introduce custom network addresses
- Refactor code and comments
- Introduce `gateways.default.ext.tlsSecretGroups.{enabled,items}
- Fix example and documentation
- Do not rely on secretName, it's not necessary.
- Introduce the `ext` field that contains the `tlsSecretGroups` one. Also, scope the `tlsSecretGroups` secrets by gateway.
- `gateway-bundle` chart v2.1.0-alpha.0
- Update documentation for Multi-SAN support
- Implement Multi-SAN support

**How did you test your code?**
n/a

**How will you confirm this change is working once it's deployed?**
n/a


[SRE-7089]: https://demoforthedaves.atlassian.net/browse/SRE-7089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ